### PR TITLE
feat: add h2 support for running integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ application-private.properties
 zz
 
 *.p12
+.idea/

--- a/phoss-ap-db/pom.xml
+++ b/phoss-ap-db/pom.xml
@@ -79,7 +79,12 @@
       <artifactId>mysql-connector-j</artifactId>
       <scope>runtime</scope>
     </dependency>
-    
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/phoss-ap-db/src/main/java/com/helger/phoss/ap/db/APJdbcMetaManager.java
+++ b/phoss-ap-db/src/main/java/com/helger/phoss/ap/db/APJdbcMetaManager.java
@@ -52,7 +52,8 @@ public final class APJdbcMetaManager extends AbstractGlobalSingleton
 {
   private static final Logger LOGGER = LoggerFactory.getLogger (APJdbcMetaManager.class);
   private static final EnumSet <EDatabaseSystemType> ALLOWED_DB_TYPES = EnumSet.of (EDatabaseSystemType.POSTGRESQL,
-                                                                                    EDatabaseSystemType.MYSQL);
+                                                                                    EDatabaseSystemType.MYSQL,
+                                                                                    EDatabaseSystemType.H2);
 
   private APJdbcConfiguration m_aJdbcConfig;
   private APDataSourceProvider m_aDSP;

--- a/phoss-ap-db/src/main/resources/db/migrate-h2/V1__InitDatabase.sql
+++ b/phoss-ap-db/src/main/resources/db/migrate-h2/V1__InitDatabase.sql
@@ -1,0 +1,222 @@
+--
+-- Copyright (C) 2026 Philip Helger (www.helger.com)
+-- philip[at]helger[dot]com
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- phoss-ap schema when phossap.jdbc.database-type=h2 (e.g. in-memory tests). Classpath: db/migrate-h2.
+-- Keep in sync with migrate-postgresql. TIMESTAMP (not TIMESTAMPTZ) for JDBC Timestamp mapping (DBResultRow).
+
+-- Outbound transactions
+CREATE TABLE outbound_transaction (
+  id                          TEXT        NOT NULL,
+  transaction_type            TEXT        NOT NULL,
+  sender_id                   TEXT        NOT NULL,
+  receiver_id                 TEXT        NOT NULL,
+  doc_type_id                 TEXT        NOT NULL,
+  process_id                  TEXT        NOT NULL,
+  sbdh_instance_id            TEXT        NOT NULL,
+  source_type                 TEXT        NOT NULL,
+  document_path               TEXT        NOT NULL,
+  document_size               BIGINT      NOT NULL,
+  document_hash               CHAR(64)    NOT NULL,
+  c1_country_code             CHAR(2)     NOT NULL,
+  status                      TEXT        NOT NULL,
+  attempt_count               INT         NOT NULL DEFAULT 0,
+  created_dt                  TIMESTAMP NOT NULL,
+  completed_dt                TIMESTAMP,
+  reporting_status            TEXT        NOT NULL,
+  next_retry_dt               TIMESTAMP,
+  error_details               TEXT,
+  mls_to                      TEXT,
+  mls_status                  TEXT,
+  mls_received_dt             TIMESTAMP,
+  mls_id                      TEXT,
+  mls_inbound_transaction_id  TEXT,
+  sbdh_standard               TEXT,
+  sbdh_type_version           TEXT,
+  sbdh_type                   TEXT,
+  payload_mime_type           TEXT,
+  CONSTRAINT pk_outbound_transaction PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_outbound_status_retry ON outbound_transaction (status, next_retry_dt);
+CREATE INDEX idx_outbound_status ON outbound_transaction (status);
+CREATE INDEX idx_outbound_sbdh_instance_id ON outbound_transaction (sbdh_instance_id);
+
+-- Outbound sending attempts
+CREATE TABLE outbound_sending_attempt (
+  id                       TEXT        NOT NULL,
+  outbound_transaction_id  TEXT        NOT NULL,
+  as4_message_id           TEXT        NOT NULL,
+  as4_timestamp            TIMESTAMP NOT NULL,
+  receipt_message_id       TEXT,
+  http_status_code         INT,
+  attempt_dt               TIMESTAMP NOT NULL,
+  attempt_status           TEXT        NOT NULL,
+  error_details            TEXT,
+  sending_report           TEXT,
+  CONSTRAINT pk_outbound_sending_attempt PRIMARY KEY (id),
+  CONSTRAINT uq_outbound_as4_message_id UNIQUE (as4_message_id),
+  CONSTRAINT fk_outbound_sending_attempt_tx FOREIGN KEY (outbound_transaction_id)
+    REFERENCES outbound_transaction (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_outbound_attempt_tx ON outbound_sending_attempt (outbound_transaction_id);
+
+-- Inbound transactions
+CREATE TABLE inbound_transaction (
+  id                            TEXT        NOT NULL,
+  incoming_id                   TEXT        NOT NULL,
+  c2_seat_id                    TEXT        NOT NULL,
+  c3_seat_id                    TEXT        NOT NULL,
+  signing_cert_cn               TEXT        NOT NULL,
+  sender_id                     TEXT        NOT NULL,
+  receiver_id                   TEXT        NOT NULL,
+  doc_type_id                   TEXT        NOT NULL,
+  process_id                    TEXT        NOT NULL,
+  document_path                 TEXT        NOT NULL,
+  document_size                 BIGINT      NOT NULL,
+  document_hash                 CHAR(64)    NOT NULL,
+  as4_message_id                TEXT        NOT NULL,
+  as4_timestamp                 TIMESTAMP NOT NULL,
+  sbdh_instance_id              TEXT        NOT NULL,
+  c1_country_code               CHAR(2),
+  c4_country_code               CHAR(2),
+  is_duplicate_as4              BOOLEAN     NOT NULL DEFAULT FALSE,
+  is_duplicate_sbdh             BOOLEAN     NOT NULL DEFAULT FALSE,
+  status                        TEXT        NOT NULL,
+  attempt_count                 INT         NOT NULL DEFAULT 0,
+  received_dt                   TIMESTAMP NOT NULL,
+  completed_dt                  TIMESTAMP,
+  reporting_status              TEXT        NOT NULL DEFAULT 'pending',
+  next_retry_dt                 TIMESTAMP,
+  error_details                 TEXT,
+  mls_to                        TEXT,
+  mls_type                      TEXT        NOT NULL,
+  mls_response_code             TEXT,
+  mls_outbound_transaction_id   TEXT,
+  CONSTRAINT pk_inbound_transaction PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_inbound_status_retry ON inbound_transaction (status, next_retry_dt);
+CREATE INDEX idx_inbound_status ON inbound_transaction (status);
+CREATE INDEX idx_inbound_as4_message_id ON inbound_transaction (as4_message_id);
+CREATE INDEX idx_inbound_sbdh_instance_id ON inbound_transaction (sbdh_instance_id);
+
+-- Inbound forwarding attempts
+CREATE TABLE inbound_forwarding_attempt (
+  id                      TEXT        NOT NULL,
+  inbound_transaction_id  TEXT        NOT NULL,
+  attempt_dt              TIMESTAMP NOT NULL,
+  attempt_status          TEXT        NOT NULL,
+  error_code              TEXT,
+  error_details           TEXT,
+  CONSTRAINT pk_inbound_forwarding_attempt PRIMARY KEY (id),
+  CONSTRAINT fk_inbound_forwarding_attempt_tx FOREIGN KEY (inbound_transaction_id)
+    REFERENCES inbound_transaction (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_inbound_attempt_tx ON inbound_forwarding_attempt (inbound_transaction_id);
+
+-- Archive tables (identical structure, no unique constraints)
+CREATE TABLE outbound_transaction_archive (
+  id                          TEXT        NOT NULL,
+  transaction_type            TEXT        NOT NULL,
+  sender_id                   TEXT        NOT NULL,
+  receiver_id                 TEXT        NOT NULL,
+  doc_type_id                 TEXT        NOT NULL,
+  process_id                  TEXT        NOT NULL,
+  sbdh_instance_id            TEXT        NOT NULL,
+  source_type                 TEXT        NOT NULL,
+  document_path               TEXT        NOT NULL,
+  document_size               BIGINT      NOT NULL,
+  document_hash               CHAR(64)    NOT NULL,
+  c1_country_code             CHAR(2)     NOT NULL,
+  status                      TEXT        NOT NULL,
+  attempt_count               INT         NOT NULL DEFAULT 0,
+  created_dt                  TIMESTAMP NOT NULL,
+  completed_dt                TIMESTAMP,
+  reporting_status            TEXT        NOT NULL DEFAULT 'pending',
+  next_retry_dt               TIMESTAMP,
+  error_details               TEXT,
+  mls_to                      TEXT,
+  mls_status                  TEXT,
+  mls_received_dt             TIMESTAMP,
+  mls_id                      TEXT,
+  mls_inbound_transaction_id  TEXT,
+  sbdh_standard               TEXT,
+  sbdh_type_version           TEXT,
+  sbdh_type                   TEXT,
+  payload_mime_type           TEXT,
+  CONSTRAINT pk_outbound_transaction_archive PRIMARY KEY (id)
+);
+
+CREATE TABLE outbound_sending_attempt_archive (
+  id                       TEXT        NOT NULL,
+  outbound_transaction_id  TEXT        NOT NULL,
+  as4_message_id           TEXT        NOT NULL,
+  as4_timestamp            TIMESTAMP NOT NULL,
+  receipt_message_id       TEXT,
+  http_status_code         INT,
+  attempt_dt               TIMESTAMP NOT NULL,
+  attempt_status           TEXT        NOT NULL,
+  error_details            TEXT,
+  sending_report           TEXT,
+  CONSTRAINT pk_outbound_sending_attempt_archive PRIMARY KEY (id)
+);
+
+CREATE TABLE inbound_transaction_archive (
+  id                            TEXT        NOT NULL,
+  incoming_id                   TEXT        NOT NULL,
+  c2_seat_id                    TEXT        NOT NULL,
+  c3_seat_id                    TEXT        NOT NULL,
+  signing_cert_cn               TEXT        NOT NULL,
+  sender_id                     TEXT        NOT NULL,
+  receiver_id                   TEXT        NOT NULL,
+  doc_type_id                   TEXT        NOT NULL,
+  process_id                    TEXT        NOT NULL,
+  document_path                 TEXT        NOT NULL,
+  document_size                 BIGINT      NOT NULL,
+  document_hash                 CHAR(64)    NOT NULL,
+  as4_message_id                TEXT        NOT NULL,
+  as4_timestamp                 TIMESTAMP NOT NULL,
+  sbdh_instance_id              TEXT        NOT NULL,
+  c1_country_code               CHAR(2),
+  c4_country_code               CHAR(2),
+  is_duplicate_as4              BOOLEAN     NOT NULL DEFAULT FALSE,
+  is_duplicate_sbdh             BOOLEAN     NOT NULL DEFAULT FALSE,
+  status                        TEXT        NOT NULL,
+  attempt_count                 INT         NOT NULL DEFAULT 0,
+  received_dt                   TIMESTAMP NOT NULL,
+  completed_dt                  TIMESTAMP,
+  reporting_status              TEXT        NOT NULL DEFAULT 'pending',
+  next_retry_dt                 TIMESTAMP,
+  error_details                 TEXT,
+  mls_to                        TEXT,
+  mls_type                      TEXT        NOT NULL,
+  mls_response_code             TEXT,
+  mls_outbound_transaction_id   TEXT,
+  CONSTRAINT pk_inbound_transaction_archive PRIMARY KEY (id)
+);
+
+CREATE TABLE inbound_forwarding_attempt_archive (
+  id                      TEXT        NOT NULL,
+  inbound_transaction_id  TEXT        NOT NULL,
+  attempt_dt              TIMESTAMP NOT NULL,
+  attempt_status          TEXT        NOT NULL,
+  error_code              TEXT,
+  error_details           TEXT,
+  CONSTRAINT pk_inbound_forwarding_attempt_archive PRIMARY KEY (id)
+);

--- a/phoss-ap-db/src/test/java/com/helger/phoss/ap/db/JdbcManagerIntegrationTest.java
+++ b/phoss-ap-db/src/test/java/com/helger/phoss/ap/db/JdbcManagerIntegrationTest.java
@@ -52,8 +52,9 @@ import com.helger.phoss.ap.basic.APBasicMetaManager;
 import com.helger.scope.mock.ScopeTestRule;
 
 /**
- * Integration tests for all JDBC managers. Uses a real PostgreSQL database. All tests share a
- * single scope/connection to avoid issues with the static DataSourceProvider in APDBExecutor.
+ * Integration tests for all JDBC managers. Uses in-memory H2 with {@code db/migrate-h2} (kept in
+ * sync with {@code db/migrate-postgresql}). All tests share a single scope/connection to avoid
+ * issues with the static DataSourceProvider in APDBExecutor.
  *
  * @author Philip Helger
  */

--- a/phoss-ap-db/src/test/java/com/helger/phoss/ap/db/config/APJdbcConfigurationTest.java
+++ b/phoss-ap-db/src/test/java/com/helger/phoss/ap/db/config/APJdbcConfigurationTest.java
@@ -45,13 +45,14 @@ public final class APJdbcConfigurationTest
   {
     final APJdbcConfiguration aJdbcConfig = new APJdbcConfiguration (APConfigProvider.getConfig ());
 
-    // Values from test application.properties
-    assertSame (EDatabaseSystemType.POSTGRESQL, aJdbcConfig.getJdbcDatabaseSystemType ());
-    assertEquals ("org.postgresql.Driver", aJdbcConfig.getJdbcDriver ());
-    assertEquals ("jdbc:postgresql://localhost:5432/phoss-ap", aJdbcConfig.getJdbcUrl ());
-    assertEquals ("peppol", aJdbcConfig.getJdbcUser ());
-    assertEquals ("peppol", aJdbcConfig.getJdbcPassword ());
-    assertEquals ("ap-test", aJdbcConfig.getJdbcSchema ());
+    // Values from test application.properties (in-memory H2)
+    assertSame (EDatabaseSystemType.H2, aJdbcConfig.getJdbcDatabaseSystemType ());
+    assertEquals ("org.h2.Driver", aJdbcConfig.getJdbcDriver ());
+    assertEquals ("jdbc:h2:mem:phoss_ap_test;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1",
+                  aJdbcConfig.getJdbcUrl ());
+    assertEquals ("sa", aJdbcConfig.getJdbcUser ());
+    assertEquals ("", aJdbcConfig.getJdbcPassword ());
+    assertEquals ("ap_test", aJdbcConfig.getJdbcSchema ());
 
     // Boolean / numeric properties return their defined defaults (not set in
     // test properties)

--- a/phoss-ap-db/src/test/resources/application.properties
+++ b/phoss-ap-db/src/test/resources/application.properties
@@ -20,13 +20,13 @@
 storage.inbound.path=generated/inbound/
 storage.outbound.path=generated/inbound/
 
-# === JDBC parameters ===
-phossap.jdbc.database-type=postgresql
-phossap.jdbc.driver=org.postgresql.Driver
-phossap.jdbc.url=jdbc:postgresql://localhost:5432/phoss-ap
-phossap.jdbc.user=peppol
-phossap.jdbc.password=peppol
-phossap.jdbc.schema=ap-test
+# === JDBC parameters (in-memory H2 — no local PostgreSQL/MySQL for CI; Flyway db/migrate-h2 in main resources) ===
+phossap.jdbc.database-type=h2
+phossap.jdbc.driver=org.h2.Driver
+phossap.jdbc.url=jdbc:h2:mem:phoss_ap_test;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
+phossap.jdbc.user=sa
+phossap.jdbc.password=
+phossap.jdbc.schema=ap_test
 
 phossap.flyway.enabled=true
 phossap.flyway.jdbc.schema-create=true

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <commons-lang.version>3.20.0</commons-lang.version>
     <failsafe.version>3.3.2</failsafe.version>
     <flyway.version>12.2.0</flyway.version>
+    <h2.version>2.3.232</h2.version>
     <jackson.version>3.1.0</jackson.version>
     <jaxb-impl.version>4.0.7</jaxb-impl.version>
     <log4j.version>2.25.3</log4j.version>
@@ -237,6 +238,12 @@
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
         <version>${mysql.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${h2.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>dev.failsafe</groupId>


### PR DESCRIPTION
- use h2 (in-memory) instead of postgres for maven tests (no running postgres instance needed during mvn test)