### PR TITLE
Fix return statement in PeppolReportingController

### DIFF
--- a/phoss-ap-webapp/src/main/java/com/helger/phoss/ap/webapp/controller/PeppolReportingController.java
+++ b/phoss-ap-webapp/src/main/java/com/helger/phoss/ap/webapp/controller/PeppolReportingController.java
@@ -169,7 +169,7 @@ public class PeppolReportingController
     // Check parameters
     final YearMonth aYearMonth = APPeppolReportHelper.getValidYearMonthInAPI (nYear, nMonth);
     if (APPeppolReportHelper.createAndSendPeppolReports (aYearMonth).isSuccess ())
-      ResponseEntity.ok ("Done - check report storage");
+      return ResponseEntity.ok ("Done - check report storage");
     return ResponseEntity.internalServerError ().body ("Error creating or sending Peppol Reports");
   }
 }


### PR DESCRIPTION
Hello,

The `createValidateStoreAndSend` is missing a `return` on the success branch, `ResponseEntity.ok(...)` is built and discarded and the method always falls through to `ResponseEntity.internalServerError()`. The endpoint returns 500 even when TSR and EUSR were sent successfully.