### PR TITLE
Add SPI-based document forwarder mode

### DIFF
--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/codelist/EForwardingMode.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/codelist/EForwardingMode.java
@@ -48,7 +48,11 @@ public enum EForwardingMode implements IHasID <String>
   /**
    * SBD is written to a local directory on the filesystem. Since v0.2.0.
    */
-  FILESYSTEM ("filesystem");
+  FILESYSTEM ("filesystem"),
+  /**
+   * SBD is forwarded by a deployment-provided document forwarder provider SPI. Since v0.9.1.
+   */
+  SPI ("spi");
 
   private final String m_sID;
 
@@ -67,7 +71,7 @@ public enum EForwardingMode implements IHasID <String>
 
   /**
    * @return <code>true</code> if this forwarding mode provides delivery confirmation (HTTP modes),
-   *         <code>false</code> if it does not (SFTP, S3).
+   *         <code>false</code> if it does not (SFTP, S3, filesystem, SPI).
    */
   public boolean isWithDeliveryConfirmation ()
   {

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
@@ -112,6 +112,14 @@ public final class APConfigurationProperties
 
   // Forwarding
   public static final String FORWARDING_MODE = "forwarding.mode";
+  /**
+   * Suffix appended to a forwarding configuration prefix to read the selected document forwarder
+   * provider SPI ID. For the primary forwarder this results in <code>forwarding.spi.id</code>; for
+   * secondary forwarders it results in <code>forwarding.secondary.{n}.spi.id</code>.
+   *
+   * @since 0.9.1
+   */
+  public static final String FORWARDING_SPI_ID_SUFFIX = "spi.id";
 
   // Forwarding - Secondary forwarders (since 0.9.0)
   /**

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/mgr/IDocumentForwarder.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/mgr/IDocumentForwarder.java
@@ -24,10 +24,9 @@ import com.helger.phoss.ap.api.model.ForwardingResult;
 import com.helger.phoss.ap.api.model.IInboundTransaction;
 
 /**
- * SPI interface for forwarding received inbound documents to the Receiver Backend (C4).
- * Implementations are loaded via {@link java.util.ServiceLoader}. Exactly one primary
- * implementation must be present on the classpath at runtime; additional secondary forwarders may
- * be configured using indexed configuration keys (see <code>forwarding.secondary.{n}.*</code>).
+ * Interface for forwarding received inbound documents to the Receiver Backend (C4). Built-in
+ * implementations are selected by <code>forwarding.mode</code>; deployment-provided implementations
+ * can be exposed through {@link com.helger.phoss.ap.api.spi.IDocumentForwarderProviderSPI}.
  *
  * @author Philip Helger
  */

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/spi/IDocumentForwarderProviderSPI.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/spi/IDocumentForwarderProviderSPI.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.api.spi;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.annotation.Nonempty;
+import com.helger.annotation.style.IsSPIInterface;
+import com.helger.phoss.ap.api.mgr.IDocumentForwarder;
+
+/**
+ * SPI interface for deployment-provided document forwarders.
+ * <p>
+ * Implementations are loaded via {@link java.util.ServiceLoader}. The AP selects one provider by
+ * matching {@link #getID()} against the configured <code>forwarding.spi.id</code> value.
+ *
+ * @author Philip Helger
+ * @since 0.9.1
+ */
+@IsSPIInterface
+public interface IDocumentForwarderProviderSPI
+{
+  /**
+   * @return The stable provider ID used in configuration. Never <code>null</code> nor empty.
+   */
+  @NonNull
+  @Nonempty
+  String getID ();
+
+  /**
+   * Create a fresh document forwarder instance. The AP initializes it afterwards with the active
+   * forwarding configuration prefix.
+   *
+   * @return A document forwarder instance. Never <code>null</code>.
+   */
+  @NonNull
+  IDocumentForwarder createDocumentForwarder ();
+}

--- a/phoss-ap-api/src/test/java/com/helger/phoss/ap/api/config/APConfigurationPropertiesTest.java
+++ b/phoss-ap-api/src/test/java/com/helger/phoss/ap/api/config/APConfigurationPropertiesTest.java
@@ -69,5 +69,6 @@ public final class APConfigurationPropertiesTest
     assertEquals ("retry.sending.max-attempts", APConfigurationProperties.RETRY_SENDING_MAX_ATTEMPTS);
     assertEquals ("mls.sending.enabled", APConfigurationProperties.MLS_SENDING_ENABLED);
     assertEquals ("mls.type", APConfigurationProperties.MLS_TYPE);
+    assertEquals ("spi.id", APConfigurationProperties.FORWARDING_SPI_ID_SUFFIX);
   }
 }

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/APCoreMetaManager.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/APCoreMetaManager.java
@@ -42,12 +42,9 @@ import com.helger.phoss.ap.api.spi.IInboundDocumentVerifierSPI;
 import com.helger.phoss.ap.api.spi.IOutboundDocumentVerifierSPI;
 import com.helger.phoss.ap.api.spi.IPeppolReceiverCheckSPI;
 import com.helger.phoss.ap.basic.APBasicConfig;
+import com.helger.phoss.ap.core.forwarding.DocumentForwarderFactory;
 import com.helger.phoss.ap.core.notification.LifecycleEventManager;
 import com.helger.phoss.ap.core.notification.NotificationHandlerManager;
-import com.helger.phoss.ap.forwarding.filesystem.FilesystemDocumentForwarder;
-import com.helger.phoss.ap.forwarding.http.HttpDocumentForwarder;
-import com.helger.phoss.ap.forwarding.s3.S3DocumentForwarder;
-import com.helger.phoss.ap.forwarding.sftp.SftpDocumentForwarder;
 import com.helger.smpclient.httpclient.SMPHttpClientSettings;
 
 /**
@@ -73,25 +70,6 @@ public final class APCoreMetaManager
   {}
 
   /**
-   * Create a new forwarder instance for the given mode. Does not initialize it from configuration.
-   *
-   * @param eMode
-   *        The forwarding mode. May not be <code>null</code>.
-   * @return A new forwarder instance. Never <code>null</code>.
-   */
-  @NonNull
-  private static IDocumentForwarder _createForwarder (@NonNull final EForwardingMode eMode)
-  {
-    return switch (eMode)
-    {
-      case HTTP_POST_SYNC, HTTP_POST_ASYNC -> new HttpDocumentForwarder (eMode);
-      case S3_LINK -> new S3DocumentForwarder ();
-      case SFTP -> new SftpDocumentForwarder ();
-      case FILESYSTEM -> new FilesystemDocumentForwarder ();
-    };
-  }
-
-  /**
    * Initialize the core meta manager by creating the document forwarder from configuration and
    * loading all SPI-based verifiers, receiver checks, and notification handlers.
    */
@@ -108,7 +86,9 @@ public final class APCoreMetaManager
       if (eForwardingMode == null)
         throw new InitializationException ("The configured Forwarding Mode '" + sForwardingMode + "' is invalid");
 
-      final IDocumentForwarder aForwarder = _createForwarder (eForwardingMode);
+      final IDocumentForwarder aForwarder = DocumentForwarderFactory.create (eForwardingMode,
+                                                                             aConfig,
+                                                                             IDocumentForwarder.DEFAULT_CONFIG_KEY_PREFIX);
       if (aForwarder.initFromConfiguration (aConfig, IDocumentForwarder.DEFAULT_CONFIG_KEY_PREFIX).isFailure ())
         throw new InitializationException ("Failed to init forwarder configuration - see logs for details");
 
@@ -138,7 +118,7 @@ public final class APCoreMetaManager
         if (nIndex > 10)
           throw new InitializationException ("No more than 10 secondary Forwarders are allowed.");
 
-        final IDocumentForwarder aSecondary = _createForwarder (eSecondaryMode);
+        final IDocumentForwarder aSecondary = DocumentForwarderFactory.create (eSecondaryMode, aConfig, sSecondaryPrefix);
         if (aSecondary.initFromConfiguration (aConfig, sSecondaryPrefix).isFailure ())
           throw new InitializationException ("Failed to init secondary forwarder #" +
                                              nIndex +

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/forwarding/DocumentForwarderFactory.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/forwarding/DocumentForwarderFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.core.forwarding;
+
+import java.util.ServiceLoader;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.exception.InitializationException;
+import com.helger.base.string.StringHelper;
+import com.helger.config.fallback.IConfigWithFallback;
+import com.helger.phoss.ap.api.codelist.EForwardingMode;
+import com.helger.phoss.ap.api.config.APConfigurationProperties;
+import com.helger.phoss.ap.api.mgr.IDocumentForwarder;
+import com.helger.phoss.ap.api.spi.IDocumentForwarderProviderSPI;
+import com.helger.phoss.ap.forwarding.filesystem.FilesystemDocumentForwarder;
+import com.helger.phoss.ap.forwarding.http.HttpDocumentForwarder;
+import com.helger.phoss.ap.forwarding.s3.S3DocumentForwarder;
+import com.helger.phoss.ap.forwarding.sftp.SftpDocumentForwarder;
+
+/**
+ * Factory for built-in and SPI-provided document forwarders.
+ *
+ * @author Philip Helger
+ * @since 0.9.1
+ */
+public final class DocumentForwarderFactory
+{
+  private DocumentForwarderFactory ()
+  {}
+
+  @NonNull
+  private static IDocumentForwarder _createSPIForwarder (@NonNull final IConfigWithFallback aConfig,
+                                                         @NonNull @Nonempty final String sKeyPrefix)
+  {
+    final String sIDKey = sKeyPrefix + APConfigurationProperties.FORWARDING_SPI_ID_SUFFIX;
+    final String sProviderID = aConfig.getAsString (sIDKey);
+    if (StringHelper.isEmpty (sProviderID))
+      throw new InitializationException ("Forwarding mode 'spi' requires configuration property '" +
+                                         sIDKey +
+                                         "' to be set");
+
+    for (final IDocumentForwarderProviderSPI aProvider : ServiceLoader.load (IDocumentForwarderProviderSPI.class))
+      if (sProviderID.equals (aProvider.getID ()))
+        return aProvider.createDocumentForwarder ();
+
+    throw new InitializationException ("No document forwarder provider SPI found for ID '" +
+                                       sProviderID +
+                                       "' from configuration property '" +
+                                       sIDKey +
+                                       "'");
+  }
+
+  /**
+   * Create a new forwarder instance for the given mode. Does not initialize it from configuration.
+   *
+   * @param eMode
+   *        The forwarding mode. May not be <code>null</code>.
+   * @param aConfig
+   *        The configuration to read from. May not be <code>null</code>.
+   * @param sKeyPrefix
+   *        The configuration prefix to use. May not be <code>null</code>.
+   * @return A new forwarder instance. Never <code>null</code>.
+   */
+  @NonNull
+  public static IDocumentForwarder create (@NonNull final EForwardingMode eMode,
+                                           @NonNull final IConfigWithFallback aConfig,
+                                           @NonNull @Nonempty final String sKeyPrefix)
+  {
+    return switch (eMode)
+    {
+      case HTTP_POST_SYNC, HTTP_POST_ASYNC -> new HttpDocumentForwarder (eMode);
+      case S3_LINK -> new S3DocumentForwarder ();
+      case SFTP -> new SftpDocumentForwarder ();
+      case FILESYSTEM -> new FilesystemDocumentForwarder ();
+      case SPI -> _createSPIForwarder (aConfig, sKeyPrefix);
+    };
+  }
+}


### PR DESCRIPTION
Introduce IDocumentForwarderProviderSPI and forwarding.mode=spi for deployment-provided forwarders selected by forwarding.spi.id. Move built-in forwarder creation into DocumentForwarderFactory so existing HTTP, S3, SFTP, and filesystem modes continue unchanged.