### PR TITLE
Add duplicate rejection notification SPI

### DIFF
--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/spi/IAPNotificationHandlerSPI.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/spi/IAPNotificationHandlerSPI.java
@@ -82,6 +82,45 @@ public interface IAPNotificationHandlerSPI
   void onOutboundVerificationRejection (@NonNull String sSbdhInstanceID, @Nullable String sErrorDetails);
 
   /**
+   * Called when an inbound AS4 message is rejected because it was detected as a duplicate before an
+   * inbound transaction could be persisted.
+   *
+   * @param sSenderID
+   *        Peppol sender ID (C1). Never <code>null</code>.
+   * @param sReceiverID
+   *        Peppol receiver ID (C4). Never <code>null</code>.
+   * @param sDocTypeID
+   *        Peppol document type ID. Never <code>null</code>.
+   * @param sProcessID
+   *        Peppol process ID. Never <code>null</code>.
+   * @param sSenderProviderID
+   *        Peppol sender provider ID (C2), usually derived from the signing certificate common name.
+   *        May be <code>null</code>.
+   * @param sAS4MessageID
+   *        AS4 Message ID. May be <code>null</code>.
+   * @param sSbdhInstanceID
+   *        SBDH Instance Identifier. Never <code>null</code>.
+   * @param bIsDuplicateAS4
+   *        <code>true</code> if an AS4 message with the same ID was previously received.
+   * @param bIsDuplicateSBDH
+   *        <code>true</code> if an SBDH with the same Instance ID was previously received.
+   * @param sErrorDetails
+   *        Error details sent back as AS4 error. Never <code>null</code>.
+   * @since 0.9.1
+   */
+  default void onInboundDuplicateRejected (@NonNull final String sSenderID,
+                                           @NonNull final String sReceiverID,
+                                           @NonNull final String sDocTypeID,
+                                           @NonNull final String sProcessID,
+                                           @Nullable final String sSenderProviderID,
+                                           @Nullable final String sAS4MessageID,
+                                           @NonNull final String sSbdhInstanceID,
+                                           final boolean bIsDuplicateAS4,
+                                           final boolean bIsDuplicateSBDH,
+                                           @NonNull final String sErrorDetails)
+  {}
+
+  /**
    * Called when the inbound message is an MLS but could not be correlated with an outbound
    * transaction.
    *

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/inbound/Phase4InboundMessageProcessorSPI.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/inbound/Phase4InboundMessageProcessorSPI.java
@@ -22,6 +22,7 @@ import java.time.ZoneOffset;
 import java.util.Locale;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.unece.cefact.namespaces.sbdh.StandardBusinessDocument;
 
@@ -87,6 +88,30 @@ import oasis.names.specification.ubl.schema.xsd.applicationresponse_21.Applicati
 public class Phase4InboundMessageProcessorSPI implements IPhase4PeppolIncomingSBDHandlerSPI
 {
   private static final Logger LOGGER = Phase4LoggerFactory.getLogger (Phase4InboundMessageProcessorSPI.class);
+
+  private static void _notifyInboundDuplicateRejected (@NonNull final String sSenderID,
+                                                       @NonNull final String sReceiverID,
+                                                       @NonNull final String sDocTypeID,
+                                                       @NonNull final String sProcessID,
+                                                       @Nullable final String sSenderProviderID,
+                                                       @Nullable final String sAS4MessageID,
+                                                       @NonNull final String sSbdhInstanceID,
+                                                       final boolean bIsDuplicateAS4,
+                                                       final boolean bIsDuplicateSBDH,
+                                                       @NonNull final String sErrorDetails)
+  {
+    for (final var aHandler : APCoreMetaManager.getAllNotificationHandlers ())
+      aHandler.onInboundDuplicateRejected (sSenderID,
+                                           sReceiverID,
+                                           sDocTypeID,
+                                           sProcessID,
+                                           sSenderProviderID,
+                                           sAS4MessageID,
+                                           sSbdhInstanceID,
+                                           bIsDuplicateAS4,
+                                           bIsDuplicateSBDH,
+                                           sErrorDetails);
+  }
 
   /** {@inheritDoc} */
   public void handleIncomingSBD (@NonNull final IAS4IncomingMessageMetadata aMessageMetadata,
@@ -175,6 +200,16 @@ public class Phase4InboundMessageProcessorSPI implements IPhase4PeppolIncomingSB
                                                                                      .refToMessageInError (aIncomingState.getMessageID ())
                                                                                      .errorDetail (sMsg))
                                                     .build ());
+              _notifyInboundDuplicateRejected (sSenderID,
+                                               sReceiverID,
+                                               sDocTypeID,
+                                               sProcessID,
+                                               sC2ID,
+                                               sAS4MessageID,
+                                               sSbdhInstanceID,
+                                               bIsDuplicateAS4,
+                                               bIsDuplicateSBDH,
+                                               sMsg);
               return;
             }
 
@@ -195,6 +230,16 @@ public class Phase4InboundMessageProcessorSPI implements IPhase4PeppolIncomingSB
                                                                                      .refToMessageInError (aIncomingState.getMessageID ())
                                                                                      .errorDetail (sMsg))
                                                     .build ());
+              _notifyInboundDuplicateRejected (sSenderID,
+                                               sReceiverID,
+                                               sDocTypeID,
+                                               sProcessID,
+                                               sC2ID,
+                                               sAS4MessageID,
+                                               sSbdhInstanceID,
+                                               bIsDuplicateAS4,
+                                               bIsDuplicateSBDH,
+                                               sMsg);
               return;
             }
 

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/notification/SafeNotificationHandler.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/notification/SafeNotificationHandler.java
@@ -83,6 +83,37 @@ public final class SafeNotificationHandler implements IAPNotificationHandlerSPI
   }
 
   /** {@inheritDoc} */
+  public void onInboundDuplicateRejected (@NonNull final String sSenderID,
+                                          @NonNull final String sReceiverID,
+                                          @NonNull final String sDocTypeID,
+                                          @NonNull final String sProcessID,
+                                          @Nullable final String sSenderProviderID,
+                                          @Nullable final String sAS4MessageID,
+                                          @NonNull final String sSbdhInstanceID,
+                                          final boolean bIsDuplicateAS4,
+                                          final boolean bIsDuplicateSBDH,
+                                          @NonNull final String sErrorDetails)
+  {
+    try
+    {
+      m_aHdl.onInboundDuplicateRejected (sSenderID,
+                                         sReceiverID,
+                                         sDocTypeID,
+                                         sProcessID,
+                                         sSenderProviderID,
+                                         sAS4MessageID,
+                                         sSbdhInstanceID,
+                                         bIsDuplicateAS4,
+                                         bIsDuplicateSBDH,
+                                         sErrorDetails);
+    }
+    catch (final Exception ex)
+    {
+      LOGGER.error ("Internal error invoking onInboundDuplicateRejected on " + m_aHdl, ex);
+    }
+  }
+
+  /** {@inheritDoc} */
   public void onInboundReceiverNotServiced (@NonNull final String sSenderID,
                                             @NonNull final String sReceiverID,
                                             @NonNull final String sDocTypeID,

--- a/phoss-ap-core/src/test/java/com/helger/phoss/ap/core/notification/SafeNotificationHandlerTest.java
+++ b/phoss-ap-core/src/test/java/com/helger/phoss/ap/core/notification/SafeNotificationHandlerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.YearMonth;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -44,6 +45,8 @@ public final class SafeNotificationHandlerTest
   {
     final AtomicInteger m_aInboundVerificationRejectionCount = new AtomicInteger (0);
     final AtomicInteger m_aOutboundVerificationRejectionCount = new AtomicInteger (0);
+    final AtomicInteger m_aInboundDuplicateRejectedCount = new AtomicInteger (0);
+    final AtomicReference <String> m_aInboundDuplicateRejectedSenderProviderID = new AtomicReference <> ();
     final AtomicInteger m_aInboundReceiverNotServicedCount = new AtomicInteger (0);
     final AtomicInteger m_aInboundMLSCorrelationErrorCount = new AtomicInteger (0);
     final AtomicInteger m_aInboundForwardingErrorCount = new AtomicInteger (0);
@@ -64,6 +67,22 @@ public final class SafeNotificationHandlerTest
                                                  @Nullable final String sErrorDetails)
     {
       m_aOutboundVerificationRejectionCount.incrementAndGet ();
+    }
+
+    @Override
+    public void onInboundDuplicateRejected (@NonNull final String sSenderID,
+                                            @NonNull final String sReceiverID,
+                                            @NonNull final String sDocTypeID,
+                                            @NonNull final String sProcessID,
+                                            @Nullable final String sSenderProviderID,
+                                            @Nullable final String sAS4MessageID,
+                                            @NonNull final String sSbdhInstanceID,
+                                            final boolean bIsDuplicateAS4,
+                                            final boolean bIsDuplicateSBDH,
+                                            @NonNull final String sErrorDetails)
+    {
+      m_aInboundDuplicateRejectedCount.incrementAndGet ();
+      m_aInboundDuplicateRejectedSenderProviderID.set (sSenderProviderID);
     }
 
     public void onInboundReceiverNotServiced (@NonNull final String sSenderID,
@@ -137,6 +156,21 @@ public final class SafeNotificationHandlerTest
       throw new RuntimeException ("test-onOutboundVerificationRejection");
     }
 
+    @Override
+    public void onInboundDuplicateRejected (@NonNull final String sSenderID,
+                                            @NonNull final String sReceiverID,
+                                            @NonNull final String sDocTypeID,
+                                            @NonNull final String sProcessID,
+                                            @Nullable final String sSenderProviderID,
+                                            @Nullable final String sAS4MessageID,
+                                            @NonNull final String sSbdhInstanceID,
+                                            final boolean bIsDuplicateAS4,
+                                            final boolean bIsDuplicateSBDH,
+                                            @NonNull final String sErrorDetails)
+    {
+      throw new RuntimeException ("test-onInboundDuplicateRejected");
+    }
+
     public void onInboundReceiverNotServiced (@NonNull final String sSenderID,
                                               @NonNull final String sReceiverID,
                                               @NonNull final String sDocTypeID,
@@ -202,6 +236,19 @@ public final class SafeNotificationHandlerTest
     aSafe.onOutboundVerificationRejection ("sbdh-out", "error");
     assertEquals (1, aInner.m_aOutboundVerificationRejectionCount.get ());
 
+    aSafe.onInboundDuplicateRejected ("sender",
+                                      "receiver",
+                                      "doctype",
+                                      "process",
+                                      "POP0000000001",
+                                      "as4-1",
+                                      "sbdh-dup",
+                                      true,
+                                      false,
+                                      "duplicate");
+    assertEquals (1, aInner.m_aInboundDuplicateRejectedCount.get ());
+    assertEquals ("POP0000000001", aInner.m_aInboundDuplicateRejectedSenderProviderID.get ());
+
     aSafe.onInboundReceiverNotServiced ("sender", "receiver", "doctype", "process", "sbdh-2");
     assertEquals (1, aInner.m_aInboundReceiverNotServicedCount.get ());
 
@@ -235,6 +282,16 @@ public final class SafeNotificationHandlerTest
     // None of these should throw
     aSafe.onInboundVerificationRejection ("tx-1", "sbdh-1", "error");
     aSafe.onOutboundVerificationRejection ("sbdh-out", "error");
+    aSafe.onInboundDuplicateRejected ("sender",
+                                      "receiver",
+                                      "doctype",
+                                      "process",
+                                      null,
+                                      null,
+                                      "sbdh-dup",
+                                      true,
+                                      false,
+                                      "duplicate");
     aSafe.onInboundReceiverNotServiced ("sender", "receiver", "doctype", "process", "sbdh-2");
     aSafe.onInboundMLSCorrelationError ("tx-2", "ref-sbdh", EPeppolMLSResponseCode.REJECTION);
     aSafe.onInboundForwardingError ("tx-3", true);


### PR DESCRIPTION
Adds a backward-compatible `onInboundDuplicateRejected(...)` SPI callback for inbound duplicate rejects before transaction creation.

Includes sender provider ID, AS4 Message ID, SBDH ID, duplicate flags, and error detail.

Tested with:

```bash
mvn -pl phoss-ap-core -am -Dtest=SafeNotificationHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test
```