### PR TITLE
Prevent S3 connection exhaustion during heavy usage.

### DIFF
--- a/phoss-ap-basic/src/main/java/com/helger/phoss/ap/basic/mgr/DocumentPayloadManagerS3.java
+++ b/phoss-ap-basic/src/main/java/com/helger/phoss/ap/basic/mgr/DocumentPayloadManagerS3.java
@@ -71,6 +71,7 @@ public class DocumentPayloadManagerS3 implements IDocumentPayloadManager
   private final class S3UploadOutputStream extends NonBlockingByteArrayOutputStream
   {
     private final String m_sKey;
+    private boolean m_bClosed;
 
     S3UploadOutputStream (@NonNull final String sKey)
     {
@@ -80,6 +81,10 @@ public class DocumentPayloadManagerS3 implements IDocumentPayloadManager
     @Override
     public void close ()
     {
+      if (m_bClosed)
+        return;
+      m_bClosed = true;
+
       try
       {
         super.close ();
@@ -307,11 +312,13 @@ public class DocumentPayloadManagerS3 implements IDocumentPayloadManager
     try
     {
       final BucketAndKey aBucketAndKey = _extractBucketAndKey (sAbsolutePath);
-      final ResponseInputStream <GetObjectResponse> aIS = m_aS3Client.getObject (GetObjectRequest.builder ()
-                                                                                                 .bucket (aBucketAndKey.bucket ())
-                                                                                                 .key (aBucketAndKey.key ())
-                                                                                                 .build ());
-      return aIS.readAllBytes ();
+      try (final ResponseInputStream<GetObjectResponse> aIS = m_aS3Client.getObject(GetObjectRequest.builder()
+                                                                                                    .bucket(aBucketAndKey.bucket())
+                                                                                                    .key(aBucketAndKey.key())
+                                                                                                    .build()))
+      {
+        return aIS.readAllBytes();
+      }
     }
     catch (final Exception ex)
     {

--- a/phoss-ap-basic/src/test/java/com/helger/phoss/ap/basic/mgr/DocumentPayloadManagerS3Test.java
+++ b/phoss-ap-basic/src/test/java/com/helger/phoss/ap/basic/mgr/DocumentPayloadManagerS3Test.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.basic.mgr;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+/**
+ * Unit tests for S3 stream lifecycle handling in {@link DocumentPayloadManagerS3}.
+ */
+public final class DocumentPayloadManagerS3Test
+{
+  private static final String BUCKET = "test-bucket";
+  private static final OffsetDateTime REFERENCE_DT = OffsetDateTime.of (2026,
+                                                                        6,
+                                                                        23,
+                                                                        10,
+                                                                        0,
+                                                                        0,
+                                                                        0,
+                                                                        ZoneOffset.UTC);
+
+  @Test
+  public void testReadDocumentClosesS3ResponseStream ()
+  {
+    final byte [] aPayload = "payload".getBytes (StandardCharsets.UTF_8);
+    final AtomicBoolean aClosed = new AtomicBoolean (false);
+    final ByteArrayInputStream aSourceIS = new ByteArrayInputStream (aPayload)
+    {
+      @Override
+      public void close ()
+      {
+        aClosed.set (true);
+      }
+    };
+    final S3Client aS3Client = _createS3Client ( (sMethodName, aArgs) -> {
+      if ("getObject".equals (sMethodName))
+        return new ResponseInputStream <> (GetObjectResponse.builder ().build (), aSourceIS);
+      throw new UnsupportedOperationException (sMethodName);
+    });
+
+    final DocumentPayloadManagerS3 aManager = new DocumentPayloadManagerS3 (aS3Client, BUCKET);
+    assertArrayEquals (aPayload, aManager.readDocument ("s3://" + BUCKET + "/document.xml"));
+    assertTrue ("The S3 response stream must be closed after reading", aClosed.get ());
+  }
+
+  @Test
+  public void testUploadStreamCloseIsIdempotent () throws Exception
+  {
+    final AtomicInteger aPutCount = new AtomicInteger ();
+    final S3Client aS3Client = _createS3Client ( (sMethodName, aArgs) -> {
+      if ("putObject".equals (sMethodName))
+      {
+        aPutCount.incrementAndGet ();
+        return PutObjectResponse.builder ().build ();
+      }
+      throw new UnsupportedOperationException (sMethodName);
+    });
+
+    final DocumentPayloadManagerS3 aManager = new DocumentPayloadManagerS3 (aS3Client, BUCKET);
+    final OutputStream aOS = aManager.openDocumentStreamForWrite ("outbound",
+                                                                  REFERENCE_DT,
+                                                                  "document",
+                                                                  ".xml",
+                                                                  sPath -> {});
+    aOS.write ("payload".getBytes (StandardCharsets.UTF_8));
+    aOS.close ();
+    aOS.close ();
+
+    assertEquals ("Closing the stream twice must upload only once", 1, aPutCount.get ());
+  }
+
+  @FunctionalInterface
+  private interface IS3InvocationHandler
+  {
+    Object invoke (String sMethodName, Object [] aArgs) throws Throwable;
+  }
+
+  private static S3Client _createS3Client (final IS3InvocationHandler aHandler)
+  {
+    return (S3Client) Proxy.newProxyInstance (DocumentPayloadManagerS3Test.class.getClassLoader (),
+                                               new Class <?> [] { S3Client.class },
+                                               (aProxy, aMethod, aArgs) -> aHandler.invoke (aMethod.getName (), aArgs));
+  }
+}

--- a/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/s3/S3DocumentForwarder.java
+++ b/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/s3/S3DocumentForwarder.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phoss.ap.forwarding.s3;
 
+import java.io.InputStream;
 import java.net.URI;
 
 import org.jspecify.annotations.NonNull;
@@ -128,7 +129,8 @@ public class S3DocumentForwarder implements IDocumentForwarder
                                                                                                     m_sSecretAccessKey)));
       }
 
-      try (final S3Client aS3Client = aBuilder.build ())
+      try (final S3Client aS3Client = aBuilder.build ();
+           final InputStream aDocumentIS = aDocPayloadMgr.openDocumentStreamForRead (aTransaction.getDocumentPath ()))
       {
         final String sKey = m_sKeyPrefix + aTransaction.getSbdhInstanceID () + ".xml";
 
@@ -139,7 +141,7 @@ public class S3DocumentForwarder implements IDocumentForwarder
                                                          .build ();
 
         final var aResult = aS3Client.putObject (aPutReq,
-                                                 RequestBody.fromInputStream (aDocPayloadMgr.openDocumentStreamForRead (aTransaction.getDocumentPath ()),
+                                                 RequestBody.fromInputStream (aDocumentIS,
                                                                               aTransaction.getDocumentSize ()));
         if (!aResult.sdkHttpResponse ().isSuccessful ())
         {


### PR DESCRIPTION
During testing, we saw a lot of "Timeout" errors from phoss-ap to our S3 storage.

There were a lot of errors, such as the following:
Timeout deadline: 10000 MILLISECONDS, actual: 10000 MILLISECONDS
Failed to delete document at 's3://phoss-ap-storage/outbound/2026/06/23/10/doc_652d7088-d1cb-4930-b500-4efc59d76bee.out']

After this fix, these errors were resolved even under heavy load.