### PR TITLE
Add outbound dev loopback for test-stage APsTest stage

### DIFF
--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
@@ -358,6 +358,10 @@ public final class APConfigurationProperties
   public static final String OUTBOUND_S3_PATH_STYLE_ACCESS = "outbound.s3.path-style-access";
   public static final boolean OUTBOUND_S3_PATH_STYLE_ACCESS_DEFAULT = false;
 
+  // Outbound local development loopback
+  public static final String OUTBOUND_DEV_LOOPBACK_ENABLED = "outbound.dev-loopback.enabled";
+  public static final boolean OUTBOUND_DEV_LOOPBACK_ENABLED_DEFAULT = false;
+
   // Directory sender (since 0.2.0)
   public static final String DIRSENDER_ENABLED = "dirsender.enabled";
   public static final boolean DIRSENDER_ENABLED_DEFAULT = false;

--- a/phoss-ap-api/src/test/java/com/helger/phoss/ap/api/config/APConfigurationPropertiesTest.java
+++ b/phoss-ap-api/src/test/java/com/helger/phoss/ap/api/config/APConfigurationPropertiesTest.java
@@ -70,5 +70,6 @@ public final class APConfigurationPropertiesTest
     assertEquals ("mls.sending.enabled", APConfigurationProperties.MLS_SENDING_ENABLED);
     assertEquals ("mls.type", APConfigurationProperties.MLS_TYPE);
     assertEquals ("spi.id", APConfigurationProperties.FORWARDING_SPI_ID_SUFFIX);
+    assertEquals ("outbound.dev-loopback.enabled", APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED);
   }
 }

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/APCoreConfig.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/APCoreConfig.java
@@ -117,6 +117,20 @@ public final class APCoreConfig
   }
 
   /**
+   * @return {@code true} if outbound sending should bypass SMP lookup and send back to this AP's
+   *         own AS4 endpoint. This is intentionally enabled only on the Peppol test network.
+   */
+  public static boolean isOutboundDevLoopbackEnabled ()
+  {
+    if (!_getConfig ().getAsBoolean (APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED,
+                                     APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED_DEFAULT))
+      return false;
+
+    final EPeppolNetwork ePeppolStage = getPeppolStage ();
+    return ePeppolStage != null && ePeppolStage.isTest ();
+  }
+
+  /**
    * @return The configured Peppol network stage (production or test). May be <code>null</code> if
    *         not configured.
    */

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/outbound/OutboundOrchestrator.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/outbound/OutboundOrchestrator.java
@@ -19,6 +19,7 @@ package com.helger.phoss.ap.core.outbound;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.DigestInputStream;
+import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -49,6 +50,7 @@ import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.IProcessIdentifier;
 import com.helger.peppolid.factory.IIdentifierFactory;
+import com.helger.phase4.crypto.AS4CryptoFactoryConfiguration;
 import com.helger.phase4.dynamicdiscovery.AS4EndpointDetailProviderConstant;
 import com.helger.phase4.dynamicdiscovery.AS4EndpointDetailProviderPeppol;
 import com.helger.phase4.dynamicdiscovery.Phase4SMPException;
@@ -68,6 +70,7 @@ import com.helger.phoss.ap.api.codelist.EAttemptStatus;
 import com.helger.phoss.ap.api.codelist.EOutboundStatus;
 import com.helger.phoss.ap.api.codelist.ESourceType;
 import com.helger.phoss.ap.api.codelist.ETransactionType;
+import com.helger.phoss.ap.api.config.APConfigurationProperties;
 import com.helger.phoss.ap.api.datetime.IAPTimestampManager;
 import com.helger.phoss.ap.api.mgr.IDocumentPayloadManager;
 import com.helger.phoss.ap.api.model.IOutboundTransaction;
@@ -539,111 +542,147 @@ public final class OutboundOrchestrator
         String sReceiverAPURLOut = null;
         String sReceiverTechnicalContactOut = null;
 
-        boolean bSmpLookupSuccess = false;
-        try (final ITelemetrySpan aSmpSpan = Telemetry.startSpan (CPhossAPOtel.SPAN_SMP_LOOKUP,
-                                                                  ETelemetrySpanKind.CLIENT)
-                                                      .setAttribute (CPhossAPOtel.ATTR_RECEIVER_ID,
-                                                                     aTx.getReceiverID ()))
+        if (APCoreConfig.isOutboundDevLoopbackEnabled ())
         {
-          try
+          final String sAPURL = APCoreConfig.getPhase4EndpointAddress ();
+          if (StringHelper.isEmpty (sAPURL))
           {
-            // SMP lookup to find endpoint URL
-            // Try to resolve SMP host - performs NAPTR lookup
-            final StopWatch aLookupSW = StopWatch.createdStarted ();
-            final SMPClientReadOnly aSMPClient;
+            final String sMsg = "Outbound dev loopback requires configuration property '" +
+                                APConfigurationProperties.PHASE4_ENDPOINT_ADDRESS +
+                                "' to be set";
+            aSendingReport.setLookupError (sMsg);
+            onPermanentFailure.accept (sMsg);
+            return aSendingReport;
+          }
+
+          final KeyStore.PrivateKeyEntry aPKE = AS4CryptoFactoryConfiguration.getDefaultInstance ().getPrivateKeyEntry ();
+          if (aPKE == null || !(aPKE.getCertificate () instanceof final X509Certificate aOwnCert))
+          {
+            final String sMsg = "Outbound dev loopback could not load this AP's own certificate from the AS4 keystore";
+            aSendingReport.setLookupError (sMsg);
+            onPermanentFailure.accept (sMsg);
+            return aSendingReport;
+          }
+
+          aReceiverCertOut = aOwnCert;
+          sReceiverAPURLOut = sAPURL;
+
+          aSendingReport.setC3Cert (aReceiverCertOut);
+          aSendingReport.setC3EndpointURL (sReceiverAPURLOut);
+
+          LOGGER.warn (sRealLogPrefix +
+                       "Outbound dev loopback is enabled; bypassing SMP lookup and sending receiver '{}' to this AP endpoint '{}'",
+                       aTx.getReceiverID (),
+                       sReceiverAPURLOut);
+        }
+        else
+        {
+          boolean bSmpLookupSuccess = false;
+          try (final ITelemetrySpan aSmpSpan = Telemetry.startSpan (CPhossAPOtel.SPAN_SMP_LOOKUP,
+                                                                    ETelemetrySpanKind.CLIENT)
+                                                        .setAttribute (CPhossAPOtel.ATTR_RECEIVER_ID,
+                                                                       aTx.getReceiverID ()))
+          {
             try
             {
-              aSMPClient = new CachingSMPClientReadOnly (PeppolNaptrURLProvider.INSTANCE, aReceiverID, aSMLInfo);
-              APBasicConfig.applyHttpProxySettings (aSMPClient.httpClientSettings ());
-
-              // Remember the host URL from NAPTR lookup
-              aSendingReport.setC3SMPURL (aSMPClient.getSMPHostURI ());
-              aSmpSpan.setAttribute (CPhossAPOtel.ATTR_SMP_URL, String.valueOf (aSMPClient.getSMPHostURI ()));
-            }
-            catch (final SMPDNSResolutionException ex)
-            {
-              final String sMsg = "The participant ID '" +
-                                  aTx.getReceiverID () +
-                                  "' is not registered in the Peppol Network";
-              aSendingReport.setLookupError (sMsg);
-              aSendingReport.setLookupException (ex);
-
-              // Remember duration
-              aLookupSW.stop ();
-              aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
-
-              onPermanentFailure.accept (sMsg + ". Technical details: " + ex.getMessage ());
-
-              return aSendingReport;
-            }
-
-            // Perform SMP lookup
-            final String sCircuitBreakerKeySMP = "smp$" + aSMPClient.getSMPHostURI ();
-            if (!CircuitBreakerManager.tryAcquirePermit (sCircuitBreakerKeySMP))
-            {
-              aLookupSW.stop ();
-              aSendingReport.setLookupError ("SMP access limited by Circuit Breaker");
-              aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
-
-              onFailed.accept ("SMP access limited by Circuit Breaker '" + sCircuitBreakerKeySMP + "'");
-              return aSendingReport;
-            }
-
-            final AS4EndpointDetailProviderPeppol aEndpointDetails = AS4EndpointDetailProviderPeppol.create (aSMPClient);
-            try
-            {
-              // Throws an exception in case of error
-              aEndpointDetails.init (aDocTypeID, aProcessID, aReceiverID);
-              aLookupSW.stop ();
-              aReceiverCertOut = aEndpointDetails.getReceiverAPCertificate ();
-              sReceiverAPURLOut = aEndpointDetails.getReceiverAPEndpointURL ();
-              sReceiverTechnicalContactOut = aEndpointDetails.getReceiverTechnicalContact ();
-
-              // Updated sending report
-              aSendingReport.setC3Cert (aReceiverCertOut);
-              aSendingReport.setC3EndpointURL (sReceiverAPURLOut);
-              aSendingReport.setC3TechnicalContact (sReceiverTechnicalContactOut);
-              aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
-
-              CircuitBreakerManager.recordSuccess (sCircuitBreakerKeySMP);
-            }
-            catch (final Phase4Exception ex)
-            {
-              CircuitBreakerManager.recordFailure (sCircuitBreakerKeySMP);
-
-              aLookupSW.stop ();
-              if (ex instanceof Phase4SMPException)
+              // SMP lookup to find endpoint URL
+              // Try to resolve SMP host - performs NAPTR lookup
+              final StopWatch aLookupSW = StopWatch.createdStarted ();
+              final SMPClientReadOnly aSMPClient;
+              try
               {
-                aSendingReport.setLookupError (ex.getMessage ());
-                aSendingReport.setLookupException ((Exception) ex.getCause ());
+                aSMPClient = new CachingSMPClientReadOnly (PeppolNaptrURLProvider.INSTANCE, aReceiverID, aSMLInfo);
+                APBasicConfig.applyHttpProxySettings (aSMPClient.httpClientSettings ());
+
+                // Remember the host URL from NAPTR lookup
+                aSendingReport.setC3SMPURL (aSMPClient.getSMPHostURI ());
+                aSmpSpan.setAttribute (CPhossAPOtel.ATTR_SMP_URL, String.valueOf (aSMPClient.getSMPHostURI ()));
               }
-              else
+              catch (final SMPDNSResolutionException ex)
               {
-                aSendingReport.setLookupError ("Error fetching Service Details from SMP");
+                final String sMsg = "The participant ID '" +
+                                    aTx.getReceiverID () +
+                                    "' is not registered in the Peppol Network";
+                aSendingReport.setLookupError (sMsg);
                 aSendingReport.setLookupException (ex);
+
+                // Remember duration
+                aLookupSW.stop ();
+                aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
+
+                onPermanentFailure.accept (sMsg + ". Technical details: " + ex.getMessage ());
+
+                return aSendingReport;
               }
-              aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
 
-              if (ex.isRetryFeasible ())
-                onFailed.accept (ex.getMessage ());
-              else
-                onPermanentFailure.accept (ex.getMessage ());
-              return aSendingReport;
+              // Perform SMP lookup
+              final String sCircuitBreakerKeySMP = "smp$" + aSMPClient.getSMPHostURI ();
+              if (!CircuitBreakerManager.tryAcquirePermit (sCircuitBreakerKeySMP))
+              {
+                aLookupSW.stop ();
+                aSendingReport.setLookupError ("SMP access limited by Circuit Breaker");
+                aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
+
+                onFailed.accept ("SMP access limited by Circuit Breaker '" + sCircuitBreakerKeySMP + "'");
+                return aSendingReport;
+              }
+
+              final AS4EndpointDetailProviderPeppol aEndpointDetails = AS4EndpointDetailProviderPeppol.create (aSMPClient);
+              try
+              {
+                // Throws an exception in case of error
+                aEndpointDetails.init (aDocTypeID, aProcessID, aReceiverID);
+                aLookupSW.stop ();
+                aReceiverCertOut = aEndpointDetails.getReceiverAPCertificate ();
+                sReceiverAPURLOut = aEndpointDetails.getReceiverAPEndpointURL ();
+                sReceiverTechnicalContactOut = aEndpointDetails.getReceiverTechnicalContact ();
+
+                // Updated sending report
+                aSendingReport.setC3Cert (aReceiverCertOut);
+                aSendingReport.setC3EndpointURL (sReceiverAPURLOut);
+                aSendingReport.setC3TechnicalContact (sReceiverTechnicalContactOut);
+                aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
+
+                CircuitBreakerManager.recordSuccess (sCircuitBreakerKeySMP);
+              }
+              catch (final Phase4Exception ex)
+              {
+                CircuitBreakerManager.recordFailure (sCircuitBreakerKeySMP);
+
+                aLookupSW.stop ();
+                if (ex instanceof Phase4SMPException)
+                {
+                  aSendingReport.setLookupError (ex.getMessage ());
+                  aSendingReport.setLookupException ((Exception) ex.getCause ());
+                }
+                else
+                {
+                  aSendingReport.setLookupError ("Error fetching Service Details from SMP");
+                  aSendingReport.setLookupException (ex);
+                }
+                aSendingReport.setLookupDurationMillis (aLookupSW.getMillis ());
+
+                if (ex.isRetryFeasible ())
+                  onFailed.accept (ex.getMessage ());
+                else
+                  onPermanentFailure.accept (ex.getMessage ());
+                return aSendingReport;
+              }
+
+              bSmpLookupSuccess = true;
             }
-
-            bSmpLookupSuccess = true;
-          }
-          catch (final RuntimeException ex)
-          {
-            aSmpSpan.recordException (ex);
-            throw ex;
-          }
-          finally
-          {
-            if (bSmpLookupSuccess)
-              aSmpSpan.setStatusOk ();
-            else
-              aSmpSpan.setStatusError (null);
+            catch (final RuntimeException ex)
+            {
+              aSmpSpan.recordException (ex);
+              throw ex;
+            }
+            finally
+            {
+              if (bSmpLookupSuccess)
+                aSmpSpan.setStatusOk ();
+              else
+                aSmpSpan.setStatusError (null);
+            }
           }
         }
 

--- a/phoss-ap-core/src/test/java/com/helger/phoss/ap/core/APCoreConfigTest.java
+++ b/phoss-ap-core/src/test/java/com/helger/phoss/ap/core/APCoreConfigTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.helger.config.ConfigFactory;
+import com.helger.config.fallback.ConfigWithFallback;
+import com.helger.config.fallback.IConfigWithFallback;
+import com.helger.phoss.ap.api.config.APConfigProvider;
+import com.helger.phoss.ap.api.config.APConfigurationProperties;
+
+/**
+ * Test class for class {@link APCoreConfig}.
+ *
+ * @author Philip Helger
+ */
+public final class APCoreConfigTest
+{
+  @Test
+  public void testOutboundDevLoopbackRequiresTestStageAndFlag ()
+  {
+    final IConfigWithFallback aOldConfig = APConfigProvider.getConfig ();
+    final String sOldStage = System.getProperty (APConfigurationProperties.PEPPOL_STAGE);
+    final String sOldFlag = System.getProperty (APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED);
+
+    try
+    {
+      System.clearProperty (APConfigurationProperties.PEPPOL_STAGE);
+      System.clearProperty (APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED);
+      APConfigProvider.setConfig (new ConfigWithFallback (ConfigFactory.createDefaultValueProvider ()));
+      assertFalse (APCoreConfig.isOutboundDevLoopbackEnabled ());
+
+      System.setProperty (APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED, "true");
+      APConfigProvider.setConfig (new ConfigWithFallback (ConfigFactory.createDefaultValueProvider ()));
+      assertFalse (APCoreConfig.isOutboundDevLoopbackEnabled ());
+
+      System.setProperty (APConfigurationProperties.PEPPOL_STAGE, "production");
+      APConfigProvider.setConfig (new ConfigWithFallback (ConfigFactory.createDefaultValueProvider ()));
+      assertFalse (APCoreConfig.isOutboundDevLoopbackEnabled ());
+
+      System.setProperty (APConfigurationProperties.PEPPOL_STAGE, "test");
+      APConfigProvider.setConfig (new ConfigWithFallback (ConfigFactory.createDefaultValueProvider ()));
+      assertTrue (APCoreConfig.isOutboundDevLoopbackEnabled ());
+    }
+    finally
+    {
+      if (sOldStage == null)
+        System.clearProperty (APConfigurationProperties.PEPPOL_STAGE);
+      else
+        System.setProperty (APConfigurationProperties.PEPPOL_STAGE, sOldStage);
+
+      if (sOldFlag == null)
+        System.clearProperty (APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED);
+      else
+        System.setProperty (APConfigurationProperties.OUTBOUND_DEV_LOOPBACK_ENABLED, sOldFlag);
+
+      APConfigProvider.setConfig (aOldConfig);
+    }
+  }
+}

--- a/phoss-ap-webapp/src/main/resources/application.properties
+++ b/phoss-ap-webapp/src/main/resources/application.properties
@@ -189,8 +189,8 @@ peppol.report.flyway.jdbc.schema-create=${phossap.flyway.jdbc.schema-create}
 #circuit-breaker.half-open-max-attempts=3
 
 # === Duplicate Detection ===
-#duplicate-detection.as4.mode=store_and_flag
-#duplicate-detection.sbdh.mode=store_and_flag
+#duplicate.detection.as4.mode=store_and_flag
+#duplicate.detection.sbdh.mode=store_and_flag
 
 # === Outbound Sending ===
 #phase4.send.timeout.connection.ms=5000


### PR DESCRIPTION
Releated #48 

## Summary

Adds an explicit outbound dev loopback mode for local/test environments.

When `outbound.dev-loopback.enabled=true` and `peppol.stage=test`, outbound sending skips SMP/SML lookup and sends the generated AS4 message to this AP's configured `phase4.endpoint.address`, using the AP's own AS4 certificate.

## Motivation

This makes local end-to-end testing easier when no SMP/SML registration or public HTTPS endpoint exists for the test participant. Developers can submit a normal outbound payload and let phoss AP perform the usual SBDH/AS4 packaging, then receive it back through the local `/as4` endpoint.

## Safety

- Disabled by default
- Explicit opt-in required
- Only active on Peppol test stage
- Production behavior unchanged

## Testing

```bash
mvn -pl phoss-ap-api,phoss-ap-core test
git diff --check
```