### PR TITLE
Add HTTP Header for Forwarding SBDH Instance ID

### DIFF
--- a/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/http/HttpDocumentForwarder.java
+++ b/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/http/HttpDocumentForwarder.java
@@ -59,6 +59,7 @@ public class HttpDocumentForwarder implements IDocumentForwarder
 {
   private static final Logger LOGGER = LoggerFactory.getLogger (HttpDocumentForwarder.class);
   private static final int MAX_CUSTOM_HEADERS = 100;
+  private static final String HEADER_SBDH_INSTANCE_ID = "X-SBDH-Instance-ID";
   // Configuration key suffixes (relative to the configured base prefix)
   private static final String SUFFIX_HTTP_ENDPOINT = "http.endpoint";
   private static final String SUFFIX_HTTP_HEADERS_PREFIX = "http.headers.";
@@ -162,6 +163,8 @@ public class HttpDocumentForwarder implements IDocumentForwarder
       // Apply custom headers (case-insensitive by using setHeader which overwrites existing)
       for (final var aEntry : m_aCustomHeaders.entrySet ())
         aPost.setHeader (aEntry.getKey (), aEntry.getValue ());
+
+      aPost.setHeader (HEADER_SBDH_INSTANCE_ID, aTransaction.getSbdhInstanceID ());
 
       LOGGER.info ("Forwarding inbound transaction '" +
                    aTransaction.getID () +


### PR DESCRIPTION
For e-reporting related concerns (to the French PPF), the SBDH Instance ID needs to be sent. Previously, in HTTP mode, the only way to obtain this ID was to fetch the SBDH document stream and deserialize it. 

This change improves efficiency by forwarding the SBDH Instance ID as an HTTP header (X-SBDH-Instance-ID), eliminating the need for document deserialization.