### PR TITLE
feat: add configurable JSON HTTP forwarding

### DIFF
--- a/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/http/HttpDocumentForwarder.java
+++ b/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/http/HttpDocumentForwarder.java
@@ -17,10 +17,12 @@
 package com.helger.phoss.ap.forwarding.http;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,8 +41,12 @@ import com.helger.httpclient.HttpClientSettingsConfig;
 import com.helger.httpclient.response.ExtendedHttpResponseException;
 import com.helger.httpclient.response.ResponseHandlerByteArray;
 import com.helger.json.IJsonObject;
+import com.helger.json.JsonObject;
 import com.helger.json.serialize.JsonReader;
+import com.helger.json.serialize.JsonWriter;
+import com.helger.json.serialize.JsonWriterSettings;
 import com.helger.phoss.ap.api.codelist.EForwardingMode;
+import com.helger.phoss.ap.api.dto.InboundTransactionResponse;
 import com.helger.phoss.ap.api.mgr.IDocumentForwarder;
 import com.helger.phoss.ap.api.mgr.IDocumentPayloadManager;
 import com.helger.phoss.ap.api.model.ForwardingResult;
@@ -62,12 +68,14 @@ public class HttpDocumentForwarder implements IDocumentForwarder
   private static final String HEADER_SBDH_INSTANCE_ID = "X-SBDH-Instance-ID";
   // Configuration key suffixes (relative to the configured base prefix)
   private static final String SUFFIX_HTTP_ENDPOINT = "http.endpoint";
+  private static final String SUFFIX_HTTP_JSON_ENABLED = "http.json.enabled";
   private static final String SUFFIX_HTTP_HEADERS_PREFIX = "http.headers.";
   private static final String SUFFIX_HTTP_HEADER_NAME = ".name";
   private static final String SUFFIX_HTTP_HEADER_VALUE = ".value";
 
   private final EForwardingMode m_eMode;
   private String m_sEndpointURL;
+  private boolean m_bJsonForwardingEnabled;
   private final HttpClientSettings m_aHCS = new HttpClientSettings ();
   private final ICommonsOrderedMap <String, String> m_aCustomHeaders = new CommonsLinkedHashMap <> ();
 
@@ -112,6 +120,7 @@ public class HttpDocumentForwarder implements IDocumentForwarder
       return ESuccess.FAILURE;
     }
 
+    m_bJsonForwardingEnabled = aConfig.getAsBoolean (sKeyPrefix + SUFFIX_HTTP_JSON_ENABLED, false);
     HttpClientSettingsConfig.assignConfigValues (m_aHCS, aConfig, sKeyPrefix);
 
     // Load custom HTTP headers (indexed: <prefix>http.headers.1.name / .value)
@@ -138,6 +147,15 @@ public class HttpDocumentForwarder implements IDocumentForwarder
     return ESuccess.SUCCESS;
   }
 
+  @NonNull
+  private static String _createJsonPayload (@NonNull final IInboundTransaction aTransaction, final byte @NonNull [] aXML)
+  {
+    final IJsonObject aJson = new JsonObject ().add ("transaction",
+                                                     InboundTransactionResponse.fromDomain (aTransaction).getAsJson ())
+                                             .add ("xmlContent", new String (aXML, StandardCharsets.UTF_8));
+    return new JsonWriter (JsonWriterSettings.DEFAULT_SETTINGS_FORMATTED).writeAsString (aJson);
+  }
+
   /** {@inheritDoc} */
   @NonNull
   public ForwardingResult forwardDocument (@NonNull final IInboundTransaction aTransaction)
@@ -157,8 +175,17 @@ public class HttpDocumentForwarder implements IDocumentForwarder
     try (final HttpClientManager aHttpClientMgr = HttpClientManager.create (m_aHCS))
     {
       final HttpPost aPost = new HttpPost (m_sEndpointURL);
-      aPost.setEntity (new InputStreamEntity (aDocPayloadMgr.openDocumentStreamForRead (aTransaction.getDocumentPath ()),
-                                              ContentType.APPLICATION_XML));
+      if (m_bJsonForwardingEnabled)
+      {
+        final byte [] aXML = aDocPayloadMgr.readDocument (aTransaction.getDocumentPath ());
+        aPost.setEntity (new StringEntity (_createJsonPayload (aTransaction, aXML),
+                                           ContentType.APPLICATION_JSON.withCharset (StandardCharsets.UTF_8)));
+      }
+      else
+      {
+        aPost.setEntity (new InputStreamEntity (aDocPayloadMgr.openDocumentStreamForRead (aTransaction.getDocumentPath ()),
+                                                ContentType.APPLICATION_XML));
+      }
 
       // Apply custom headers (case-insensitive by using setHeader which overwrites existing)
       for (final var aEntry : m_aCustomHeaders.entrySet ())
@@ -172,7 +199,9 @@ public class HttpDocumentForwarder implements IDocumentForwarder
                    aTransaction.getSbdhInstanceID () +
                    "') to '" +
                    m_sEndpointURL +
-                   "'");
+                   "' as " +
+                   (m_bJsonForwardingEnabled ? "JSON" : "XML") +
+                   " payload");
 
       final byte [] aResponse = aHttpClientMgr.execute (aPost, new ResponseHandlerByteArray ());
       return switch (m_eMode)
@@ -243,6 +272,7 @@ public class HttpDocumentForwarder implements IDocumentForwarder
   {
     return new ToStringGenerator (this).append ("Mode", m_eMode)
                                        .append ("EnpointURL", m_sEndpointURL)
+                                       .append ("JsonForwardingEnabled", m_bJsonForwardingEnabled)
                                        .append ("HCS", m_aHCS)
                                        .append ("CustomHeaders", m_aCustomHeaders.size ())
                                        .getToString ();

--- a/phoss-ap-forwarding/src/test/java/com/helger/phoss/ap/forwarding/http/HttpDocumentForwarderTest.java
+++ b/phoss-ap-forwarding/src/test/java/com/helger/phoss/ap/forwarding/http/HttpDocumentForwarderTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.forwarding.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.OffsetDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.helger.config.ConfigFactory;
+import com.helger.config.fallback.ConfigWithFallback;
+import com.helger.config.fallback.IConfigWithFallback;
+import com.helger.json.IJsonObject;
+import com.helger.json.serialize.JsonReader;
+import com.helger.peppol.mls.EPeppolMLSResponseCode;
+import com.helger.peppol.sbdh.EPeppolMLSType;
+import com.helger.phoss.ap.api.codelist.EForwardingMode;
+import com.helger.phoss.ap.api.codelist.EInboundStatus;
+import com.helger.phoss.ap.api.codelist.EReportingStatus;
+import com.helger.phoss.ap.api.config.APConfigurationProperties;
+import com.helger.phoss.ap.api.model.IInboundTransaction;
+import com.helger.scope.mock.ScopeTestRule;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Test class for class {@link HttpDocumentForwarder}.
+ *
+ * @author Philip Helger
+ */
+public final class HttpDocumentForwarderTest
+{
+  @Rule
+  public final TemporaryFolder m_aTempFolder = new TemporaryFolder ();
+
+  @Rule
+  public final ScopeTestRule m_aScopeRule = new ScopeTestRule ();
+
+  @NonNull
+  private static IConfigWithFallback _createConfig ()
+  {
+    return new ConfigWithFallback (ConfigFactory.createDefaultValueProvider ());
+  }
+
+  @NonNull
+  private static IInboundTransaction _createTransaction (@NonNull final String sDocumentPath, final long nDocumentSize)
+  {
+    return new IInboundTransaction ()
+    {
+      public String getID () { return "tx-1"; }
+      public String getIncomingID () { return "incoming-1"; }
+      public String getC2SeatID () { return "C2-SEAT"; }
+      public String getC3SeatID () { return "C3-SEAT"; }
+      public String getSigningCertCN () { return "signing-cn"; }
+      public String getSenderID () { return "iso6523-actorid-upis::sender"; }
+      public String getReceiverID () { return "iso6523-actorid-upis::receiver"; }
+      public String getDocTypeID () { return "doctype"; }
+      public String getProcessID () { return "process"; }
+      public String getDocumentPath () { return sDocumentPath; }
+      public long getDocumentSize () { return nDocumentSize; }
+      public String getDocumentHash () { return "hash"; }
+      public String getAS4MessageID () { return "as4-message"; }
+      public OffsetDateTime getAS4Timestamp () { return OffsetDateTime.parse ("2026-01-02T03:04:05Z"); }
+      public String getSbdhInstanceID () { return "sbdh-1"; }
+      public String getC1CountryCode () { return "DE"; }
+      public String getC4CountryCode () { return "AT"; }
+      public boolean isDuplicateAS4 () { return false; }
+      public boolean isDuplicateSBDH () { return false; }
+      public EInboundStatus getStatus () { return EInboundStatus.RECEIVED; }
+      public int getAttemptCount () { return 1; }
+      public OffsetDateTime getReceivedDT () { return OffsetDateTime.parse ("2026-01-02T03:05:05Z"); }
+      public OffsetDateTime getCompletedDT () { return null; }
+      public EReportingStatus getReportingStatus () { return EReportingStatus.PENDING; }
+      public OffsetDateTime getNextRetryDT () { return null; }
+      public String getErrorDetails () { return null; }
+      public String getMlsTo () { return null; }
+      public EPeppolMLSType getMlsType () { return EPeppolMLSType.ALWAYS_SEND; }
+      public EPeppolMLSResponseCode getMlsResponseCode () { return null; }
+      public String getMlsOutboundTransactionID () { return null; }
+    };
+  }
+
+  private static HttpServer _startServer (@NonNull final AtomicReference <String> aContentType,
+                                          @NonNull final AtomicReference <String> aBody) throws IOException
+  {
+    final HttpServer aServer = HttpServer.create (new InetSocketAddress ("127.0.0.1", 0), 0);
+    aServer.createContext ("/forward", aExchange -> {
+      aContentType.set (aExchange.getRequestHeaders ().getFirst ("Content-Type"));
+      aBody.set (new String (aExchange.getRequestBody ().readAllBytes (), StandardCharsets.UTF_8));
+      aExchange.sendResponseHeaders (204, -1);
+      aExchange.close ();
+    });
+    aServer.start ();
+    return aServer;
+  }
+
+  private void _runForwardingTest (final boolean bJsonEnabled,
+                                   @NonNull final AtomicReference <String> aContentType,
+                                   @NonNull final AtomicReference <String> aBody) throws Exception
+  {
+    final byte [] aXML = "<Invoice><ID>123</ID></Invoice>".getBytes (StandardCharsets.UTF_8);
+    final var aXMLFile = m_aTempFolder.newFile ("document.xml").toPath ();
+    Files.write (aXMLFile, aXML);
+
+    System.setProperty (APConfigurationProperties.STORAGE_INBOUND_PATH, m_aTempFolder.newFolder ("inbound").getAbsolutePath ());
+    System.setProperty (APConfigurationProperties.STORAGE_OUTBOUND_PATH, m_aTempFolder.newFolder ("outbound").getAbsolutePath ());
+
+    final HttpServer aServer = _startServer (aContentType, aBody);
+    try
+    {
+      final int nPort = aServer.getAddress ().getPort ();
+      System.setProperty ("forwarding.http.endpoint", "http://127.0.0.1:" + nPort + "/forward");
+      System.setProperty ("forwarding.http.json.enabled", Boolean.toString (bJsonEnabled));
+
+      final HttpDocumentForwarder aForwarder = new HttpDocumentForwarder (EForwardingMode.HTTP_POST_ASYNC);
+      assertTrue (aForwarder.initFromConfiguration (_createConfig (), "forwarding.").isSuccess ());
+      assertTrue (aForwarder.forwardDocument (_createTransaction (aXMLFile.toString (), aXML.length)).isSuccess ());
+    }
+    finally
+    {
+      aServer.stop (0);
+      System.clearProperty ("forwarding.http.endpoint");
+      System.clearProperty ("forwarding.http.json.enabled");
+      System.clearProperty (APConfigurationProperties.STORAGE_INBOUND_PATH);
+      System.clearProperty (APConfigurationProperties.STORAGE_OUTBOUND_PATH);
+    }
+  }
+
+  @Test
+  public void testXmlForwardingIsDefault () throws Exception
+  {
+    final AtomicReference <String> aContentType = new AtomicReference <> ();
+    final AtomicReference <String> aBody = new AtomicReference <> ();
+
+    _runForwardingTest (false, aContentType, aBody);
+
+    assertNotNull (aContentType.get ());
+    assertTrue (aContentType.get ().startsWith ("application/xml"));
+    assertEquals ("<Invoice><ID>123</ID></Invoice>", aBody.get ());
+  }
+
+  @Test
+  public void testJsonForwardingIncludesXmlContent () throws Exception
+  {
+    final AtomicReference <String> aContentType = new AtomicReference <> ();
+    final AtomicReference <String> aBody = new AtomicReference <> ();
+
+    _runForwardingTest (true, aContentType, aBody);
+
+    assertNotNull (aContentType.get ());
+    assertTrue (aContentType.get ().startsWith ("application/json"));
+
+    final IJsonObject aJson = JsonReader.builder ().source (aBody.get ()).readAsObject ();
+    assertNotNull (aJson);
+    assertEquals ("<Invoice><ID>123</ID></Invoice>", aJson.getAsString ("xmlContent"));
+    assertTrue (aBody.get ().contains ("\"transaction\""));
+    assertTrue (aBody.get ().contains ("\"tx-1\""));
+  }
+}

--- a/phoss-ap-webapp/src/main/resources/application.properties
+++ b/phoss-ap-webapp/src/main/resources/application.properties
@@ -224,6 +224,9 @@ peppol.report.flyway.jdbc.schema-create=${phossap.flyway.jdbc.schema-create}
 
 forwarding.mode=http_post_async
 forwarding.http.endpoint=http://localhost:8888/forwarding/url/async
+# Keep XML forwarding by default. Set to true to send an application/json payload
+# with transaction metadata and the original XML in the "xmlContent" field.
+#forwarding.http.json.enabled=false
 # S3 forwarding endpoint override
 #forwarding.s3.endpoint=https://s3.example.com
 #forwarding.s3.path-style-access=true


### PR DESCRIPTION
## Summary

- Adds `forwarding.http.json.enabled` for HTTP document forwarding.
- Keeps existing XML forwarding as the default behavior.
- Sends JSON with transaction metadata and `xmlContent` containing the original XML when enabled.
- Documents the flag in the sample application configuration.

Fixes #54.

## Validation

- `mvn -pl phoss-ap-forwarding -am test -DskipITs`

## Notes

README intentionally left unchanged. Please update the wiki/configuration