### PR TITLE
feat: add generic SPI hook for custom document payload storage backends

### DIFF
--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/codelist/EStorageMode.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/codelist/EStorageMode.java
@@ -39,7 +39,11 @@ public enum EStorageMode implements IHasID <String>
   /**
    * Store messages on S3. Supported since v0.1.1
    */
-  S3 ("s3");
+  S3 ("s3"),
+  /**
+   * Store messages in the relational database. Supported since v0.10.4
+   */
+  DB ("db");
 
   public static final EStorageMode DEFAULT = FILE_SYSTEM;
 

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/spi/IDocumentPayloadManagerProviderSPI.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/spi/IDocumentPayloadManagerProviderSPI.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.api.spi;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.annotation.style.IsSPIInterface;
+import com.helger.phoss.ap.api.mgr.IDocumentPayloadManager;
+
+/**
+ * SPI interface to dynamically load an {@link IDocumentPayloadManager} via {@link java.util.ServiceLoader}.
+ *
+ * @author Philip Helger
+ */
+@IsSPIInterface
+public interface IDocumentPayloadManagerProviderSPI
+{
+  /**
+   * @return A new instance of the document payload manager. Never <code>null</code>.
+   */
+  @NonNull
+  IDocumentPayloadManager createManager ();
+}

--- a/phoss-ap-basic/src/main/java/com/helger/phoss/ap/basic/APBasicMetaManager.java
+++ b/phoss-ap-basic/src/main/java/com/helger/phoss/ap/basic/APBasicMetaManager.java
@@ -70,21 +70,7 @@ public final class APBasicMetaManager extends AbstractGlobalSingleton
     LOGGER.info ("Initializing " + ClassHelper.getClassLocalName (this));
     try
     {
-      // Initialize document payload manager
-      m_aDocPayloadMgr = switch (APBasicConfig.getStorageMode ())
-      {
-        case FILE_SYSTEM ->
-        {
-          LOGGER.info ("Using filesystem document storage backend");
-          yield new DocumentPayloadManagerFileSystem ();
-        }
-        case S3 ->
-        {
-          LOGGER.info ("Using S3 document storage backend");
-          yield new DocumentPayloadManagerS3 ();
-        }
-      };
-      m_aDocPayloadMgr.verifyConfiguration ();
+      m_aTimestampMgr = new APTimestampManager ();
 
       // Determine identifier factory from configuration
       m_aIdentifierFactory = switch (APBasicConfig.getPeppolIdentifierMode ())
@@ -101,7 +87,29 @@ public final class APBasicMetaManager extends AbstractGlobalSingleton
         }
       };
 
-      m_aTimestampMgr = new APTimestampManager ();
+      // Initialize document payload manager
+      m_aDocPayloadMgr = switch (APBasicConfig.getStorageMode ())
+      {
+        case FILE_SYSTEM ->
+        {
+          LOGGER.info ("Using filesystem document storage backend");
+          yield new DocumentPayloadManagerFileSystem ();
+        }
+        case S3 ->
+        {
+          LOGGER.info ("Using S3 document storage backend");
+          yield new DocumentPayloadManagerS3 ();
+        }
+        case DB ->
+        {
+          LOGGER.info ("Using DB document storage backend via SPI");
+          yield java.util.ServiceLoader.load (com.helger.phoss.ap.api.spi.IDocumentPayloadManagerProviderSPI.class)
+                                       .findFirst ()
+                                       .orElseThrow (() -> new IllegalStateException ("No DB Payload Manager SPI provider found on the classpath!"))
+                                       .createManager ();
+        }
+      };
+      m_aDocPayloadMgr.verifyConfiguration ();
 
       LOGGER.info (ClassHelper.getClassLocalName (this) + " was initialized");
     }

--- a/phoss-ap-db/src/main/java/com/helger/phoss/ap/db/flyway/APFlywayMigrator.java
+++ b/phoss-ap-db/src/main/java/com/helger/phoss/ap/db/flyway/APFlywayMigrator.java
@@ -56,9 +56,17 @@ public final class APFlywayMigrator
       return;
     }
 
+    final String sBaseLocation = "db/phoss-ap-flyway-" + aJdbcConfig.getJdbcDatabaseSystemType ().getID ();
+    final boolean bHasPayloadDbSPI = java.util.ServiceLoader.load (com.helger.phoss.ap.api.spi.IDocumentPayloadManagerProviderSPI.class)
+                                                            .iterator ()
+                                                            .hasNext ();
+
+    final String sLocations = bHasPayloadDbSPI ? sBaseLocation + ",db/phoss-ap-flyway-payload-" + aJdbcConfig.getJdbcDatabaseSystemType ().getID ()
+                                               : sBaseLocation;
+
     FlywayMigrationRunner.runFlyway (aJdbcConfig,
                                      aFlywayCfg,
-                                     "db/phoss-ap-flyway-" + aJdbcConfig.getJdbcDatabaseSystemType ().getID (),
+                                     sLocations,
                                      (JavaMigration []) null,
                                      (Callback []) null);
   }


### PR DESCRIPTION
```markdown
### Description
Introduces an SPI to support custom document payload storage backends. This allows downstream integrations (e.g., storing payloads in databases or cloud storage) to plug in custom `IDocumentPayloadManager` implementations without adding custom schemas or dependencies to the core repository.

### Changes
* **`phoss-ap-api`**: Added `IDocumentPayloadManagerProviderSPI` interface and registered `DB` in `EStorageMode`.
* **`phoss-ap-basic`**: Updated `APBasicMetaManager` to dynamically resolve custom managers via `ServiceLoader` at startup.
* **`phoss-ap-db`**: Updated `APFlywayMigrator` to scan classpath SPI presence and dynamically append custom schema migration paths (e.g., `db/phoss-ap-flyway-payload-[dbtype]`) to Flyway. [I did not want to touch this module but could not find any other way make that work; flyway locations property did not work]

