### PR TITLE
feat: add deferred document verification fail-mode and retry support …

### DIFF
--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/codelist/EVerificationOutcomeCategory.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/codelist/EVerificationOutcomeCategory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.api.codelist;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.id.IHasID;
+import com.helger.base.lang.EnumHelper;
+
+/**
+ * Outcome category of a document verification attempt.
+ *
+ * @author Philip Helger
+ */
+public enum EVerificationOutcomeCategory implements IHasID <String>
+{
+  /** Document inspected and passed (clean / valid schema). */
+  PASSED ("passed"),
+  /** Document inspected and explicitly rejected due to content/rules (malware, invalid UBL). */
+  REJECTION ("rejection"),
+  /** Verifier backend service was unavailable (ICAP socket connection refused, Phorm 5xx). */
+  SERVICE_UNAVAILABLE ("service_unavailable");
+
+  private final String m_sID;
+
+  EVerificationOutcomeCategory (@NonNull @Nonempty final String sID)
+  {
+    m_sID = sID;
+  }
+
+  /** {@inheritDoc} */
+  @NonNull
+  @Nonempty
+  public String getID ()
+  {
+    return m_sID;
+  }
+
+  /**
+   * Find the enum constant matching the given ID.
+   *
+   * @param sID
+   *        The ID to look up. May be <code>null</code>.
+   * @return The matching enum constant, or <code>null</code> if not found.
+   */
+  @Nullable
+  public static EVerificationOutcomeCategory getFromIDOrNull (@Nullable final String sID)
+  {
+    return EnumHelper.getFromIDOrNull (EVerificationOutcomeCategory.class, sID);
+  }
+}

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
@@ -298,6 +298,8 @@ public final class APConfigurationProperties
   public static final boolean VERIFICATION_OUTBOUND_ENABLED_DEFAULT = false;
   public static final String VERIFICATION_INBOUND_ENABLED = "verification.inbound.enabled";
   public static final boolean VERIFICATION_INBOUND_ENABLED_DEFAULT = false;
+  public static final String VERIFICATION_VERIFIER_FAIL_MODE = "verification.verifier-fail-mode";
+  public static final String VERIFICATION_VERIFIER_FAIL_MODE_DEFAULT = "closed";
   public static final String VERIFICATION_PHORM_URL = "verification.phorm.url";
   public static final String VERIFICATION_PHORM_TOKEN = "verification.phorm.token";
 

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/exception/InboundVerifierDeferredException.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/exception/InboundVerifierDeferredException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.ap.api.exception;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.enforce.ValueEnforcer;
+
+/**
+ * Exception thrown by an {@link com.helger.phoss.ap.api.spi.IInboundDocumentVerifierSPI} when
+ * verification cannot be completed due to verifier service unavailability in
+ * <code>deferred</code> fail mode, signaling to hold/defer processing without sending an immediate
+ * permanent MLS rejection.
+ *
+ * @author Philip Helger
+ */
+public class InboundVerifierDeferredException extends RuntimeException
+{
+  private final String m_sVerifierName;
+
+  /**
+   * Constructor.
+   *
+   * @param sVerifierName
+   *        The class or display name of the verifier that was unavailable. May not be
+   *        <code>null</code> nor empty.
+   * @param sErrorMessage
+   *        The error message detailing the service unavailability. May not be <code>null</code> nor
+   *        empty.
+   */
+  public InboundVerifierDeferredException (@NonNull @Nonempty final String sVerifierName,
+                                           @NonNull @Nonempty final String sErrorMessage)
+  {
+    super (sErrorMessage);
+    m_sVerifierName = ValueEnforcer.notEmpty (sVerifierName, "VerifierName");
+  }
+
+  /**
+   * @return The name of the verifier that was unavailable. Never <code>null</code> nor empty.
+   */
+  @NonNull
+  @Nonempty
+  public String getVerifierName ()
+  {
+    return m_sVerifierName;
+  }
+}

--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/model/MlsOutcome.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/model/MlsOutcome.java
@@ -33,6 +33,8 @@ import com.helger.peppol.mls.EPeppolMLSResponseCode;
 import com.helger.peppol.mls.PeppolMLSBuilder;
 import com.helger.peppol.mls.PeppolMLSLineResponseBuilder;
 
+import com.helger.phoss.ap.api.codelist.EVerificationOutcomeCategory;
+
 /**
  * Immutable DTO that captures the outcome of inbound document processing, used to drive MLS
  * response creation. Carries the overall response code, an optional human-readable response text,
@@ -61,6 +63,7 @@ public final class MlsOutcome
 {
   private final EPeppolMLSResponseCode m_eResponseCode;
   private final String m_sResponseText;
+  private final EVerificationOutcomeCategory m_eCategory;
   private final ICommonsOrderedMap <String, ICommonsList <MlsOutcomeIssue>> m_aIssues = new CommonsLinkedHashMap <> ();
 
   /**
@@ -78,9 +81,37 @@ public final class MlsOutcome
                      @Nullable final String sResponseText,
                      @Nullable final Iterable <? extends MlsOutcomeIssue> aIssues)
   {
+    this (eResponseCode,
+          sResponseText,
+          aIssues,
+          eResponseCode.isFailure () ? EVerificationOutcomeCategory.REJECTION
+                                     : EVerificationOutcomeCategory.PASSED);
+  }
+
+  /**
+   * Full constructor with explicit category.
+   *
+   * @param eResponseCode
+   *        The overall MLS response code. May not be <code>null</code>.
+   * @param sResponseText
+   *        Optional human-readable response text. May be <code>null</code>.
+   * @param aIssues
+   *        Optional list of issues. May be <code>null</code> or empty for non-rejection responses.
+   *        For rejection responses at least one issue is required.
+   * @param eCategory
+   *        The verification outcome category. May not be <code>null</code>.
+   * @since 0.11.1
+   */
+  public MlsOutcome (@NonNull final EPeppolMLSResponseCode eResponseCode,
+                     @Nullable final String sResponseText,
+                     @Nullable final Iterable <? extends MlsOutcomeIssue> aIssues,
+                     @NonNull final EVerificationOutcomeCategory eCategory)
+  {
     ValueEnforcer.notNull (eResponseCode, "ResponseCode");
+    ValueEnforcer.notNull (eCategory, "Category");
     m_eResponseCode = eResponseCode;
     m_sResponseText = sResponseText;
+    m_eCategory = eCategory;
     // Group by error field
     if (aIssues != null)
       for (final var aIssue : aIssues)
@@ -205,6 +236,16 @@ public final class MlsOutcome
   }
 
   /**
+   * @return The verification outcome category. Never <code>null</code>.
+   * @since 0.11.1
+   */
+  @NonNull
+  public EVerificationOutcomeCategory getCategory ()
+  {
+    return m_eCategory;
+  }
+
+  /**
    * Create a rejection outcome (response code RE) with a single issue.
    *
    * @param sResponseText
@@ -234,5 +275,47 @@ public final class MlsOutcome
   {
     ValueEnforcer.notEmpty (aIssues, "Issues");
     return new MlsOutcome (EPeppolMLSResponseCode.REJECTION, sResponseText, aIssues);
+  }
+
+  /**
+   * Create a service unavailable outcome (response code RE) for verifier backend infrastructure
+   * outages.
+   *
+   * @param sResponseText
+   *        Human-readable response text. May be <code>null</code>.
+   * @param aIssue
+   *        The rejection issue. May not be <code>null</code>.
+   * @return A new {@link MlsOutcome} with response code {@link EPeppolMLSResponseCode#REJECTION}
+   *         and category {@link EVerificationOutcomeCategory#SERVICE_UNAVAILABLE}.
+   * @since 0.11.1
+   */
+  @NonNull
+  public static MlsOutcome serviceUnavailable (@Nullable final String sResponseText,
+                                               @NonNull final MlsOutcomeIssue aIssue)
+  {
+    return serviceUnavailable (sResponseText, new CommonsArrayList <> (aIssue));
+  }
+
+  /**
+   * Create a service unavailable outcome (response code RE) for verifier backend infrastructure
+   * outages.
+   *
+   * @param sResponseText
+   *        Human-readable response text. May be <code>null</code>.
+   * @param aIssues
+   *        The rejection issues. May not be <code>null</code> or empty.
+   * @return A new {@link MlsOutcome} with response code {@link EPeppolMLSResponseCode#REJECTION}
+   *         and category {@link EVerificationOutcomeCategory#SERVICE_UNAVAILABLE}.
+   * @since 0.11.1
+   */
+  @NonNull
+  public static MlsOutcome serviceUnavailable (@Nullable final String sResponseText,
+                                               @NonNull @Nonempty final List <MlsOutcomeIssue> aIssues)
+  {
+    ValueEnforcer.notEmpty (aIssues, "Issues");
+    return new MlsOutcome (EPeppolMLSResponseCode.REJECTION,
+                           sResponseText,
+                           aIssues,
+                           EVerificationOutcomeCategory.SERVICE_UNAVAILABLE);
   }
 }

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/APCoreConfig.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/APCoreConfig.java
@@ -661,6 +661,18 @@ public final class APCoreConfig
   }
 
   /**
+   * @return The system-wide verifier failure handling mode (e.g. <code>"closed"</code>,
+   *         <code>"open"</code>, <code>"deferred"</code>). Never <code>null</code>.
+   * @since 0.11.1
+   */
+  @NonNull
+  public static String getVerificationVerifierFailMode ()
+  {
+    return _getConfig ().getAsString (APConfigurationProperties.VERIFICATION_VERIFIER_FAIL_MODE,
+                                      APConfigurationProperties.VERIFICATION_VERIFIER_FAIL_MODE_DEFAULT);
+  }
+
+  /**
    * @return {@code true} if MLS sending is globally enabled. Defaults to {@code true}.
    * @since v0.1.2
    */

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/inbound/InboundOrchestrator.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/inbound/InboundOrchestrator.java
@@ -44,6 +44,7 @@ import com.helger.peppol.sbdh.PeppolSBDHData;
 import com.helger.peppolid.CIdentifier;
 import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IProcessIdentifier;
+import com.helger.peppolid.factory.IIdentifierFactory;
 import com.helger.peppolid.peppol.PeppolIdentifierHelper;
 import com.helger.peppolid.peppol.spis.SPIDHelper;
 import com.helger.phoss.ap.api.CPhossAP;
@@ -51,6 +52,8 @@ import com.helger.phoss.ap.api.IInboundForwardingAttemptManager;
 import com.helger.phoss.ap.api.IInboundTransactionManager;
 import com.helger.phoss.ap.api.codelist.EDuplicateDetectionMode;
 import com.helger.phoss.ap.api.codelist.EInboundStatus;
+import com.helger.phoss.ap.api.codelist.EVerificationOutcomeCategory;
+import com.helger.phoss.ap.api.exception.InboundVerifierDeferredException;
 import com.helger.phoss.ap.api.datetime.IAPTimestampManager;
 import com.helger.phoss.ap.api.mgr.IDocumentForwarder;
 import com.helger.phoss.ap.api.mgr.IDocumentPayloadManager;
@@ -400,39 +403,95 @@ public final class InboundOrchestrator
                                                            .setAttribute (CPhossAPOtel.ATTR_SBDH_INSTANCE_ID,
                                                                           sSbdhInstanceID))
           {
-            // Call callbacks
-            for (final IInboundDocumentVerifierSPI aVerifier : APCoreMetaManager.getAllInboundVerifiers ())
+            try
             {
-              final MlsOutcome aVerifierOutcome = aVerifier.verifyInboundDocument (sDocumentPath,
-                                                                                   aDocTypeID,
-                                                                                   aProcessID);
-              if (aVerifierOutcome != null && aVerifierOutcome.getResponseCode ().isFailure ())
+              // Call registered SPI verifiers
+              for (final IInboundDocumentVerifierSPI aVerifier : APCoreMetaManager.getAllInboundVerifiers ())
               {
-                aVerifySpan.setStatusError ("Inbound verification failed");
-                LOGGER.warn (sLogPrefix + "Inbound document verification failed for '" + sSbdhInstanceID + "'");
-                aInboundMgr.updateStatus (sTxID, EInboundStatus.REJECTED);
-
-                // Dop't send MLS as response to MLR or MLS
-                if (!CPhossAP.isMLR (aDocTypeID, aProcessID) && !CPhossAP.isMLS (aDocTypeID, aProcessID))
+                final MlsOutcome aVerifierOutcome = aVerifier.verifyInboundDocument (sDocumentPath,
+                                                                                     aDocTypeID,
+                                                                                     aProcessID);
+                if (aVerifierOutcome != null && aVerifierOutcome.getResponseCode ().isFailure ())
                 {
-                  // Send asynchronously
-                  PhotonWorkerPool.getInstance ().run ("send-mls", () -> {
-                    // Send negative MLS (RE) back to C2 with the verifier's detailed outcome
-                    MlsHandler.triggerSendingInboundResultMls (aInboundTx, aVerifierOutcome);
-                  });
+                  final String sOutcomeText = aVerifierOutcome.getResponseText ();
+
+                  // Check if verifier service is unavailable under deferred fail-mode
+                  if (aVerifierOutcome.getCategory () == EVerificationOutcomeCategory.SERVICE_UNAVAILABLE &&
+                      "deferred".equalsIgnoreCase (APCoreConfig.getVerificationVerifierFailMode ()))
+                  {
+                    aVerifySpan.setStatusError ("Inbound verification service unavailable (deferred)");
+                    LOGGER.warn (sLogPrefix +
+                                 "Inbound verifier service unavailable for '" +
+                                 sSbdhInstanceID +
+                                 "' (deferred for retry)");
+
+                    // Queue for automatic retry with backoff schedule (do NOT send immediate MLS rejection)
+                    final var aNextRetry = BackoffCalculator.calculateNextRetry (1,
+                                                                                APCoreConfig.getRetryForwardingInitialBackoff (),
+                                                                                APCoreConfig.getRetryForwardingBackoffMultiplier (),
+                                                                                APCoreConfig.getRetryForwardingMaxBackoff ());
+                    aInboundMgr.updateStatusAndRetry (sTxID,
+                                                      EInboundStatus.FORWARD_FAILED,
+                                                      1,
+                                                      aNextRetry,
+                                                      "VERIFIER_UNAVAILABLE: " + sOutcomeText);
+                    return aProcessingErrors;
+                  }
+
+                  // Hard rejection (invalid business rules, malware) or fail-closed mode
+                  aVerifySpan.setStatusError ("Inbound verification failed");
+                  LOGGER.warn (sLogPrefix + "Inbound document verification failed for '" + sSbdhInstanceID + "'");
+                  aInboundMgr.updateStatusAndRetry (sTxID,
+                                                    EInboundStatus.REJECTED,
+                                                    0,
+                                                    null,
+                                                    "VERIFICATION_REJECTED: " + sOutcomeText);
+
+                  // Don't send MLS as response to MLR or MLS
+                  if (!CPhossAP.isMLR (aDocTypeID, aProcessID) && !CPhossAP.isMLS (aDocTypeID, aProcessID))
+                  {
+                    // Send negative MLS (RE) back to C2 asynchronously
+                    PhotonWorkerPool.getInstance ().run ("send-mls", () -> {
+                      MlsHandler.triggerSendingInboundResultMls (aInboundTx, aVerifierOutcome);
+                    });
+                  }
+
+                  // Notify lifecycle listeners of rejection
+                  for (final var aHandler : APCoreMetaManager.getAllNotificationHandlers ())
+                    aHandler.onInboundVerificationRejection (sTxID, sSbdhInstanceID, "Inbound verification failed");
+
+                  return aProcessingErrors;
                 }
-
-                // No processing error - MLS
-
-                for (final var aHandler : APCoreMetaManager.getAllNotificationHandlers ())
-                  aHandler.onInboundVerificationRejection (sTxID, sSbdhInstanceID, "Inbound verification failed");
-                return aProcessingErrors;
               }
-            }
 
-            // All verifiers accepted
-            for (final var aHandler : APCoreMetaManager.getAllLifecycleHandlers ())
-              aHandler.onInboundVerificationAccepted (sTxID, sSbdhInstanceID);
+              // All verifiers accepted
+              for (final var aHandler : APCoreMetaManager.getAllLifecycleHandlers ())
+                aHandler.onInboundVerificationAccepted (sTxID, sSbdhInstanceID);
+            }
+            catch (final InboundVerifierDeferredException ex)
+            {
+              // Catch SPI verifiers that explicitly throw InboundVerifierDeferredException
+              aVerifySpan.setStatusError ("Inbound verification deferred: " + ex.getMessage ());
+              LOGGER.warn (sLogPrefix +
+                           "Inbound document verification deferred for '" +
+                           sSbdhInstanceID +
+                           "': " +
+                           ex.getMessage ());
+
+              final var aNextRetry = BackoffCalculator.calculateNextRetry (1,
+                                                                          APCoreConfig.getRetryForwardingInitialBackoff (),
+                                                                          APCoreConfig.getRetryForwardingBackoffMultiplier (),
+                                                                          APCoreConfig.getRetryForwardingMaxBackoff ());
+              aInboundMgr.updateStatusAndRetry (sTxID,
+                                                EInboundStatus.FORWARD_FAILED,
+                                                1,
+                                                aNextRetry,
+                                                "VERIFIER_UNAVAILABLE [" +
+                                                            ex.getVerifierName () +
+                                                            "]: " +
+                                                            ex.getMessage ());
+              return aProcessingErrors;
+            }
           }
         }
 
@@ -796,5 +855,109 @@ public final class InboundOrchestrator
     }
 
     return bForwardSuccess ? ESuccess.SUCCESS : ESuccess.FAILURE;
+  }
+
+  /**
+   * Re-verify an inbound document against all SPI verifiers before attempting forwarding to C4.
+   *
+   * @param sLogPrefix
+   *        Log message prefix for traceability. May not be <code>null</code>.
+   * @param aInboundTx
+   *        The inbound transaction to re-verify and forward. May not be <code>null</code>.
+   * @return {@link ESuccess#SUCCESS} if re-verification and forwarding succeeded,
+   *         {@link ESuccess#FAILURE} otherwise.
+   * @since 0.11.1
+   */
+  @NonNull
+  public static ESuccess reverifyAndForwardInboundDocument (@NonNull final String sLogPrefix,
+                                                            @NonNull final IInboundTransaction aInboundTx)
+  {
+    if (APCoreConfig.isVerificationInboundEnabled ())
+    {
+      final IInboundTransactionManager aTxMgr = APJdbcMetaManager.getInboundTransactionMgr ();
+      final String sTxID = aInboundTx.getID ();
+      final String sSbdhInstanceID = aInboundTx.getSbdhInstanceID ();
+      final IIdentifierFactory aIF = APBasicMetaManager.getIdentifierFactory ();
+      final IDocumentTypeIdentifier aDocTypeID = aIF.createDocumentTypeIdentifierWithDefaultScheme (aInboundTx.getDocTypeID ());
+      final IProcessIdentifier aProcessID = aIF.createProcessIdentifierWithDefaultScheme (aInboundTx.getProcessID ());
+      final String sDocumentPath = aInboundTx.getDocumentPath ();
+      final int nNewAttemptCount = aInboundTx.getAttemptCount () + 1;
+
+      try
+      {
+        // Re-evaluate all registered SPI verifiers
+        for (final IInboundDocumentVerifierSPI aVerifier : APCoreMetaManager.getAllInboundVerifiers ())
+        {
+          final MlsOutcome aVerifierOutcome = aVerifier.verifyInboundDocument (sDocumentPath,
+                                                                               aDocTypeID,
+                                                                               aProcessID);
+          if (aVerifierOutcome != null && aVerifierOutcome.getResponseCode ().isFailure ())
+          {
+            final String sOutcomeText = aVerifierOutcome.getResponseText ();
+
+            // Check if verifier service is unavailable under deferred fail-mode
+            if (aVerifierOutcome.getCategory () == EVerificationOutcomeCategory.SERVICE_UNAVAILABLE &&
+                "deferred".equalsIgnoreCase (APCoreConfig.getVerificationVerifierFailMode ()))
+            {
+              LOGGER.warn (sLogPrefix +
+                           "Re-verification service unavailable for '" +
+                           sSbdhInstanceID +
+                           "' (deferred for retry)");
+
+              // Re-schedule for next retry interval
+              final var aNextRetry = BackoffCalculator.calculateNextRetry (nNewAttemptCount,
+                                                                          APCoreConfig.getRetryForwardingInitialBackoff (),
+                                                                          APCoreConfig.getRetryForwardingBackoffMultiplier (),
+                                                                          APCoreConfig.getRetryForwardingMaxBackoff ());
+              aTxMgr.updateStatusAndRetry (sTxID,
+                                           EInboundStatus.FORWARD_FAILED,
+                                           nNewAttemptCount,
+                                           aNextRetry,
+                                           "VERIFIER_UNAVAILABLE: " + sOutcomeText);
+              return ESuccess.FAILURE;
+            }
+
+            // Hard rejection (invalid business rules, malware) or fail-closed mode
+            LOGGER.warn (sLogPrefix + "Re-verification failed for '" + sSbdhInstanceID + "'");
+            aTxMgr.updateStatusAndRetry (sTxID,
+                                         EInboundStatus.REJECTED,
+                                         nNewAttemptCount,
+                                         null,
+                                         "VERIFICATION_REJECTED: " + sOutcomeText);
+            if (!CPhossAP.isMLR (aDocTypeID, aProcessID) && !CPhossAP.isMLS (aDocTypeID, aProcessID))
+            {
+              // Send negative MLS (RE) back to C2 asynchronously
+              PhotonWorkerPool.getInstance ().run ("send-mls", () -> {
+                MlsHandler.triggerSendingInboundResultMls (aInboundTx, aVerifierOutcome);
+              });
+            }
+            return ESuccess.FAILURE;
+          }
+        }
+      }
+      catch (final InboundVerifierDeferredException ex)
+      {
+        // Catch SPI verifiers that explicitly throw InboundVerifierDeferredException
+        LOGGER.warn (sLogPrefix +
+                     "Re-verification deferred for '" +
+                     sSbdhInstanceID +
+                     "': " +
+                     ex.getMessage ());
+
+        final var aNextRetry = BackoffCalculator.calculateNextRetry (nNewAttemptCount,
+                                                                    APCoreConfig.getRetryForwardingInitialBackoff (),
+                                                                    APCoreConfig.getRetryForwardingBackoffMultiplier (),
+                                                                    APCoreConfig.getRetryForwardingMaxBackoff ());
+        aTxMgr.updateStatusAndRetry (sTxID,
+                                     EInboundStatus.FORWARD_FAILED,
+                                     nNewAttemptCount,
+                                     aNextRetry,
+                                     "VERIFIER_UNAVAILABLE [" + ex.getVerifierName () + "]: " + ex.getMessage ());
+        return ESuccess.FAILURE;
+      }
+    }
+
+    // Forward document to C4 if all verifiers passed
+    return forwardDocument (sLogPrefix, aInboundTx);
   }
 }

--- a/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/job/RetryScheduler.java
+++ b/phoss-ap-core/src/main/java/com/helger/phoss/ap/core/job/RetryScheduler.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import com.helger.annotation.Nonnegative;
 import com.helger.base.exception.InitializationException;
+import com.helger.base.state.ESuccess;
+import com.helger.base.string.StringHelper;
 import com.helger.base.timing.StopWatch;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.phoss.ap.api.model.IInboundTransaction;
@@ -140,8 +142,15 @@ public final class RetryScheduler
           for (final IInboundTransaction aInboundTx : aTransactions)
           {
             nProcessed++;
-            // Re-forward using the original InboundOrchestrator logic
-            if (InboundOrchestrator.forwardDocument (sLogPrefix, aInboundTx).isFailure ())
+            final String sErrorDetails = aInboundTx.getErrorDetails ();
+            final boolean bWasDeferred = StringHelper.hasText (sErrorDetails) &&
+                                         sErrorDetails.startsWith ("VERIFIER_UNAVAILABLE");
+
+            final ESuccess eSuccess = bWasDeferred ? InboundOrchestrator.reverifyAndForwardInboundDocument (sLogPrefix,
+                                                                                                           aInboundTx)
+                                                   : InboundOrchestrator.forwardDocument (sLogPrefix,
+                                                                                          aInboundTx);
+            if (eSuccess.isFailure ())
             {
               for (final var aHandler : APCoreMetaManager.getAllNotificationHandlers ())
                 aHandler.onInboundForwardingError (aInboundTx.getID (), true);

--- a/phoss-ap-webapp/src/main/java/com/helger/phoss/ap/webapp/controller/OperationsController.java
+++ b/phoss-ap-webapp/src/main/java/com/helger/phoss/ap/webapp/controller/OperationsController.java
@@ -151,6 +151,35 @@ public class OperationsController
     final IInboundTransaction aUpdatedTx = aTxMgr.getBySbdhInstanceIDIncludingArchive (sbdhInstanceID);
     final IInboundTransaction aFinalTx = aUpdatedTx != null ? aUpdatedTx : aTx;
 
+  if (eSuccess.isSuccess ())
+      return ResponseEntity.ok (InboundTransactionResponse.fromDomain (aFinalTx));
+    return ResponseEntity.internalServerError ().body (InboundTransactionResponse.fromDomain (aFinalTx));
+  }
+
+  /**
+   * Re-verify against all registered SPI verifiers and forward an inbound transaction.
+   *
+   * @param sbdhInstanceID
+   *        The SBDH Instance ID of the transaction to re-verify and forward.
+   * @return 200 on success, 404 if not found, 500 on failure.
+   * @since 0.11.1
+   */
+  @PostMapping ("/inbound/{sbdhInstanceID}/reverify-and-forward")
+  @Operation (summary = "Re-verify and forward an inbound transaction",
+              description = "Re-evaluates all registered SPI verifiers against the stored payload before forwarding.")
+  @ApiResponses ({ @ApiResponse (responseCode = "200", description = "Transaction re-verification and forwarding initiated"),
+                   @ApiResponse (responseCode = "404", description = "Transaction not found", content = @Content) })
+  public ResponseEntity <InboundTransactionResponse> reverifyAndForwardInbound (@Parameter (description = "SBDH Instance ID", required = true) @PathVariable ("sbdhInstanceID") final String sbdhInstanceID)
+  {
+    final IInboundTransactionManager aTxMgr = APJdbcMetaManager.getInboundTransactionMgr ();
+    final IInboundTransaction aTx = aTxMgr.getBySbdhInstanceIDIncludingArchive (sbdhInstanceID);
+    if (aTx == null)
+      return ResponseEntity.notFound ().build ();
+
+    final ESuccess eSuccess = InboundOrchestrator.reverifyAndForwardInboundDocument ("API ReverifyAndForward: ", aTx);
+    final IInboundTransaction aUpdatedTx = aTxMgr.getBySbdhInstanceIDIncludingArchive (sbdhInstanceID);
+    final IInboundTransaction aFinalTx = aUpdatedTx != null ? aUpdatedTx : aTx;
+
     if (eSuccess.isSuccess ())
       return ResponseEntity.ok (InboundTransactionResponse.fromDomain (aFinalTx));
     return ResponseEntity.internalServerError ().body (InboundTransactionResponse.fromDomain (aFinalTx));

--- a/phoss-ap-webapp/src/main/resources/application.properties
+++ b/phoss-ap-webapp/src/main/resources/application.properties
@@ -255,6 +255,8 @@ forwarding.http.endpoint=http://localhost:8888/forwarding/url/async
 # before forwarding.
 #verification.inbound.enabled=false
 #verification.outbound.enabled=false
+# System-wide verifier failure handling mode: "closed" (default), "open", "deferred"
+#verification.verifier-fail-mode=closed
 # Base URL of the phorm Validation Service (the built-in verifier calls its
 # "/api/dd_and_validate/" endpoint). Required when verification is enabled.
 #verification.phorm.url=http://localhost:8080


### PR DESCRIPTION
## Feature: Deferred Document Verification Fail-Mode & Retry Support (#71)
### Context & Motivation
- This change stems from the implementation of external document verifiers (such as an ICAP-based Virus Scanning verifier; see [#71](https://github.com/phax/phoss-ap/issues/71)). 
- When external verification services (e.g., antivirus scanners, validation microservices, or ICAP servers) experience transient downtime or connectivity issues, rejecting incoming documents immediately (`fail-closed`) can disrupt business document processing unnecessarily. Conversely, bypassing verification (`fail-open`) introduces security risks.
To address this, this PR introduces a **deferred verification fail-mode** (`verification.verifier-fail-mode=deferred`). In `deferred` mode, transient infrastructure errors set inbound transactions to `FORWARD_FAILED` with an exponential backoff schedule, allowing `phoss-ap`'s built-in `RetryScheduler` to automatically re-evaluate verification once the external service recovers.
---
## Key Changes
### 1. API & Core Infrastructure (`phoss-ap-api`, `phoss-ap-core`)
- **Outcome Categorization (`EVerificationOutcomeCategory`)**: Defines outcome categories (`PASSED`, `REJECTION`, `SERVICE_UNAVAILABLE`) to distinguish between document validation rule failures (malware / invalid UBL schema) and service availability issues (ICAP socket connection refused, HTTP 5xx).
- **MLS Outcome Enhancements (`MlsOutcome`)**:
  - Added `EVerificationOutcomeCategory` field and `getCategory()` getter to carry outcome classification alongside standard Peppol MLS response codes (`EPeppolMLSResponseCode`).
  - Added `MlsOutcome.serviceUnavailable(...)` factory methods to construct outcomes explicitly tagged as `SERVICE_UNAVAILABLE`.
  - Enables `InboundOrchestrator` to inspect whether a verifier failure was caused by service unavailability rather than a hard business rule rejection.
- **Deferred Verification Exception (`InboundVerifierDeferredException`)**: Standard exception type for SPI verifiers to throw when backends are offline/unreachable under `deferred` mode.
- **Orchestration & MLS Behavior (`InboundOrchestrator`)**:
  - **In `deferred` mode**: When a verifier returns `SERVICE_UNAVAILABLE` (or throws `InboundVerifierDeferredException`), **no immediate MLS rejection (`RE`) is sent** back to the sender (C2). Sending a rejection prematurely would signal permanent failure to C2 and break retry semantics. Instead, the transaction status is set to `FORWARD_FAILED` with an exponential backoff schedule (`aNextRetry`) for automatic background retries.
  - **In `closed` mode**: An immediate MLS rejection (`RE`) with `FAILURE_OF_DELIVERY` status reason code is sent back to C2, and the transaction is marked as `REJECTED`.
  - Hard validation rejections (malware or invalid business rules → status `REJECTED`) always send a negative MLS (`RE`) regardless of fail-mode.
- **Retry Scheduler (`RetryScheduler`)**: Automatically re-evaluates verification for deferred inbound documents when their retry timer expires.
### 2. Operations API (`phoss-ap-webapp`)
- **Re-verify Endpoint**: Added `/api/ops/inbound/{sbdhInstanceID}/reverify-and-forward` to `OperationsController` to support manual re-triggering of SPI verifiers and document forwarding via REST.
---
…(#71)