### PR TITLE
feat(forwarding): add configurable filename pattern for SFTP forwarding

### DIFF
--- a/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
+++ b/phoss-ap-api/src/main/java/com/helger/phoss/ap/api/config/APConfigurationProperties.java
@@ -192,6 +192,8 @@ public final class APConfigurationProperties
   // Forwarding - SFTP
   /** @since 0.10.2 */
   public static final boolean FORWARDING_SFTP_WRITE_METADATA_DEFAULT = false;
+  /** @since 0.12.0 */
+  public static final String FORWARDING_SFTP_FILENAME_PATTERN_DEFAULT = "{datetime}_{incoming-id}";
 
   // Retry sending
   public static final String RETRY_SENDING_MAX_ATTEMPTS = "retry.sending.max-attempts";

--- a/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/sftp/SftpDocumentForwarder.java
+++ b/phoss-ap-forwarding/src/main/java/com/helger/phoss/ap/forwarding/sftp/SftpDocumentForwarder.java
@@ -68,9 +68,11 @@ public class SftpDocumentForwarder implements IDocumentForwarder
   // the base path for SftpSettings.createFromConfig
   private static final String SUFFIX_SFTP_BASE = "sftp";
   private static final String SUFFIX_SFTP_WRITE_METADATA = "sftp.write-metadata";
+  private static final String SUFFIX_SFTP_FILENAME_PATTERN = "sftp.filename-pattern";
 
   private ISftpSettings m_aSftpSettings;
   private boolean m_bWriteMetadata;
+  private String m_sFilenamePattern;
 
   /** {@inheritDoc} */
   @NonNull
@@ -88,8 +90,20 @@ public class SftpDocumentForwarder implements IDocumentForwarder
 
     m_bWriteMetadata = aConfig.getAsBoolean (sKeyPrefix + SUFFIX_SFTP_WRITE_METADATA,
                                              APConfigurationProperties.FORWARDING_SFTP_WRITE_METADATA_DEFAULT);
+    m_sFilenamePattern = aConfig.getAsString (sKeyPrefix + SUFFIX_SFTP_FILENAME_PATTERN,
+                                              APConfigurationProperties.FORWARDING_SFTP_FILENAME_PATTERN_DEFAULT);
 
     return ESuccess.SUCCESS;
+  }
+
+  /**
+   * @return The configured filename pattern. Never <code>null</code>.
+   * @since 0.12.0
+   */
+  @NonNull
+  public final String getFilenamePattern ()
+  {
+    return m_sFilenamePattern;
   }
 
   /**
@@ -234,17 +248,49 @@ public class SftpDocumentForwarder implements IDocumentForwarder
   }
 
   @NonNull
+  static String getResolvedBaseName (@NonNull final String sPattern,
+                                     @NonNull final IInboundTransaction aTransaction)
+  {
+    final String sDT = DateTimeFormatter.ofPattern (SFTP_DATETIME_PATTERN).format (aTransaction.getReceivedDT ());
+    final String sIncomingID = FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getIncomingID ());
+    final String sSbdhInstanceID = FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getSbdhInstanceID ());
+
+    final String sReceiverID = aTransaction.getReceiverID ();
+    final int nReceiverColon = sReceiverID.lastIndexOf (':');
+    final String sReceiverValue = nReceiverColon >= 0 ? sReceiverID.substring (nReceiverColon + 1) : sReceiverID;
+
+    final String sSenderID = aTransaction.getSenderID ();
+    final int nSenderColon = sSenderID.lastIndexOf (':');
+    final String sSenderValue = nSenderColon >= 0 ? sSenderID.substring (nSenderColon + 1) : sSenderID;
+
+    String sResult = sPattern;
+    sResult = sResult.replace ("${datetime}", sDT).replace ("{datetime}", sDT);
+    sResult = sResult.replace ("${incoming-id}", sIncomingID).replace ("{incoming-id}", sIncomingID);
+    sResult = sResult.replace ("${sbdh-instance-id}", sSbdhInstanceID).replace ("{sbdh-instance-id}", sSbdhInstanceID);
+    sResult = sResult.replace ("${receiver-id}", FilenameHelper.getAsSecureValidASCIIFilename (sReceiverID))
+                     .replace ("{receiver-id}", FilenameHelper.getAsSecureValidASCIIFilename (sReceiverID));
+    sResult = sResult.replace ("${receiver-value}", FilenameHelper.getAsSecureValidASCIIFilename (sReceiverValue))
+                     .replace ("{receiver-value}", FilenameHelper.getAsSecureValidASCIIFilename (sReceiverValue));
+    sResult = sResult.replace ("${sender-id}", FilenameHelper.getAsSecureValidASCIIFilename (sSenderID))
+                     .replace ("{sender-id}", FilenameHelper.getAsSecureValidASCIIFilename (sSenderID));
+    sResult = sResult.replace ("${sender-value}", FilenameHelper.getAsSecureValidASCIIFilename (sSenderValue))
+                     .replace ("{sender-value}", FilenameHelper.getAsSecureValidASCIIFilename (sSenderValue));
+    sResult = sResult.replace ("${doctype-id}", FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getDocTypeID ()))
+                     .replace ("{doctype-id}", FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getDocTypeID ()));
+    sResult = sResult.replace ("${process-id}", FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getProcessID ()))
+                     .replace ("{process-id}", FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getProcessID ()));
+
+    return FilenameHelper.getAsSecureValidASCIIFilename (sResult);
+  }
+
+  @NonNull
   private ForwardingResult _doForwardDocument (@NonNull final IInboundTransaction aTransaction)
   {
     try
     {
       final IDocumentPayloadManager aDocPayloadMgr = APBasicMetaManager.getDocPayloadMgr ();
 
-      // Layout: yyyyMMddHHmmss_(random value)
-      final String sBaseName = DateTimeFormatter.ofPattern (SFTP_DATETIME_PATTERN)
-                                                .format (aTransaction.getReceivedDT ()) +
-                               "_" +
-                               FilenameHelper.getAsSecureValidASCIIFilename (aTransaction.getIncomingID ());
+      final String sBaseName = getResolvedBaseName (m_sFilenamePattern, aTransaction);
 
       final ForwardingResult aResult = writeUploadedFile (m_aSftpSettings,
                                                           "",
@@ -285,6 +331,7 @@ public class SftpDocumentForwarder implements IDocumentForwarder
   public String toString ()
   {
     return new ToStringGenerator (this).append ("SftpSettings", m_aSftpSettings)
+                                       .append ("FilenamePattern", m_sFilenamePattern)
                                        .append ("WriteMetadata", m_bWriteMetadata)
                                        .getToString ();
   }

--- a/phoss-ap-webapp/src/main/resources/application.properties
+++ b/phoss-ap-webapp/src/main/resources/application.properties
@@ -234,6 +234,11 @@ forwarding.http.endpoint=http://localhost:8888/forwarding/url/async
 # S3 forwarding endpoint override
 #forwarding.s3.endpoint=https://s3.example.com
 #forwarding.s3.path-style-access=true
+# Optional SFTP filename pattern (default: {datetime}_{incoming-id})
+# Supported placeholders: {datetime}, {incoming-id}, {sbdh-instance-id}, {receiver-id},
+#   {receiver-value}, {sender-id}, {sender-value}, {doctype-id}, {process-id}
+#forwarding.sftp.filename-pattern={datetime}_{incoming-id}
+
 
 # === Retry (Forwarding) ===
 # Duration values use suffixes: ns, us, ms, s, m, h, d (e.g. "1m", "1h 30m")


### PR DESCRIPTION
### Summary
This PR introduces a configurable filename pattern for SFTP forwarding (`forwarding.sftp.filename-pattern`). It enables downstream routing services (e.g. integration middleware) to route received documents to C4 receivers based on participant metadata (such as receiver ID) without needing to open and parse the XML payload or manage companion JSON sidecars.

### Changes
* **`APConfigurationProperties`**: Added `FORWARDING_SFTP_FILENAME_PATTERN_DEFAULT = "{datetime}_{incoming-id}"`.
* **`SftpDocumentForwarder`**:
  * Added `forwarding.sftp.filename-pattern` configuration property handling and `getFilenamePattern()` getter.
  * Added helper method `getResolvedBaseName(...)` to substitute placeholders and sanitize all dynamic values using `FilenameHelper.getAsSecureValidASCIIFilename(...)`.
* **`application.properties`**: Documented `forwarding.sftp.filename-pattern` and its supported placeholders.

### Configuration & Placeholders
* **Property:** `forwarding.sftp.filename-pattern` (default: `{datetime}_{incoming-id}`)
* **Supported Placeholders:**
  * `{datetime}`: Reception timestamp formatted as `yyyyMMddHHmmss`
  * `{incoming-id}`: Phase4 inbound transaction incoming ID / UUID
  * `{sbdh-instance-id}`: SBDH Instance Identifier
  * `{receiver-id}`: Sanitized full receiver participant ID (e.g. `0151_35747532810`)
  * `{receiver-value}`: Receiver participant value without scheme (e.g. `35747532810`)
  * `{sender-id}`: Sanitized full sender participant ID
  * `{sender-value}`: Sender participant value without scheme
  * `{doctype-id}`: Sanitized Document Type ID
  * `{process-id}`: Sanitized Process ID
* Supports both `{token}` and `${token}` placeholder syntax.

### Backward Compatibility
* 100% backward compatible: defaults to `{datetime}_{incoming-id}`, producing identical filenames to previous versions.
* If metadata sidecar creation is enabled (`forwarding.sftp.write-metadata=true`), the companion `.json` file shares the exact matching resolved base name as the `.xml`.

closes #90 